### PR TITLE
Fix missed TCM when touching multiple cards

### DIFF
--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -39,7 +39,7 @@ export class State {
      * @param {number} ourPlayerIndex
      * @param {string[]} suits
      */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, level) {
+	constructor(tableID, playerNames, ourPlayerIndex, suits) {
 		/** @type {number} */
 		this.tableID = tableID;
 		/** @type {string[]} */

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -130,10 +130,13 @@ function find_tcm(state, target, saved_cards, trash_card) {
 				}
 			}
 
-			const touch = state.hands[target].clueTouched(state.suits, clue);
-			const { focused_card } = determine_focus(state.hands[target], touch.map(c => c.order), { beforeClue: true });
+			return true;
 
-			return focused_card.order === trash_card.order;
+			// Card doesn't need to be focused?
+			// const touch = state.hands[target].clueTouched(state.suits, clue);
+			// const { focused_card } = determine_focus(state.hands[target], touch.map(c => c.order), { beforeClue: true });
+
+			// return focused_card.order === trash_card.order;
 		});
 
 		if (tcm !== undefined) {

--- a/test/h-group/level-1.js
+++ b/test/h-group/level-1.js
@@ -3,80 +3,17 @@ import { strict as assert } from 'node:assert';
 // @ts-ignore
 import { describe, it } from 'node:test';
 
+import { COLOUR, PLAYER, setup, getRawInferences, expandShortCard } from '../test-utils.js';
 import HGroup from '../../src/conventions/h-group.js';
-import { Card } from '../../src/basics/Card.js';
 import { CLUE } from '../../src/constants.js';
 import * as Utils from '../../src/util.js';
 import logger from '../../src/logger.js';
-
-const COLOUR = Object.freeze({
-	RED: 0,
-	YELLOW: 1,
-	GREEN: 2,
-	BLUE: 3,
-	PURPLE: 4
-});
-
-const PLAYER = Object.freeze({
-	ALICE: 0,
-	BOB: 1,
-	CATHY: 2,
-	DONALD: 3,
-	EMILY: 4
-});
-
-/**
- * @param {string[][]} hands
- */
-function setup(hands) {
-	const playerNames = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'].slice(0, hands.length);
-	const suits = ['Red', 'Yellow', 'Green', 'Blue', 'Purple'];
-
-	const state = new HGroup(-1, playerNames, 1, suits);
-	Utils.globalModify({state});
-
-	let orderCounter = 0;
-
-	// Draw all the hands
-	for (let playerIndex = 0; playerIndex < hands.length; playerIndex++) {
-		const hand = hands[playerIndex];
-		for (const short of hand.reverse()) {
-			const card = expandShortCard(short);
-			if (card.suitIndex !== -1) {
-				console.log('EEEEE');
-			}
-			const action = { type: 'draw', order: orderCounter, playerIndex, suitIndex: card.suitIndex, rank: card.rank };
-			orderCounter++;
-
-			state.handle_action(action);
-		}
-	}
-
-	return state;
-}
-
-/**
- * @param {string} short
- */
-function expandShortCard(short) {
-	return {
-		suitIndex: ['x', 'r', 'y', 'g', 'b', 'p'].indexOf(short[0]) - 1,
-		rank: Number(short[1]) || -1
-	};
-}
-
-/**
- * @param  {Card} card [description]
- */
-function getRawInferences(card) {
-	return card.inferred.map(c => Utils.objPick(c, ['suitIndex', 'rank']));
-}
 
 logger.setLevel(logger.LEVELS.ERROR);
 
 describe('play clue', () => {
 	it('can interpret a colour play clue touching one card', () => {
-		const state = setup([
+		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'xx', 'xx', 'xx', 'xx']
 		]);
@@ -91,7 +28,7 @@ describe('play clue', () => {
 	});
 
 	it('can interpret a colour play clue touching multiple cards', () => {
-		const state = setup([
+		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'xx', 'xx', 'xx', 'xx']
 		]);
@@ -106,7 +43,7 @@ describe('play clue', () => {
 	});
 
 	it('can interpret a colour play clue touching chop', () => {
-		const state = setup([
+		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'xx', 'xx', 'xx', 'xx']
 		]);
@@ -121,7 +58,7 @@ describe('play clue', () => {
 	});
 
 	it('can interpret a colour play clue on a partial stack', () => {
-		const state = setup([
+		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'xx', 'xx', 'xx', 'xx']
 		]);
@@ -138,7 +75,7 @@ describe('play clue', () => {
 	});
 
 	it('can interpret a colour play clue through someone\'s hand', () => {
-		const state = setup([
+		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'r1', 'xx', 'xx', 'xx']
@@ -160,7 +97,7 @@ describe('play clue', () => {
 	});
 
 	it('can interpret a self-connecting colour play clue', () => {
-		const state = setup([
+		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 		]);

--- a/test/h-group/level-1.js
+++ b/test/h-group/level-1.js
@@ -85,7 +85,6 @@ describe('play clue', () => {
 		state.hands[PLAYER.CATHY][1].clued = true;
 		state.hands[PLAYER.CATHY][1].intersect('possible', ['r1', 'r2', 'r3', 'r4', 'r5'].map(expandShortCard));
 		state.hands[PLAYER.CATHY][1].intersect('inferred', ['r1'].map(expandShortCard));
-		console.log(Utils.logHand(state.hands[PLAYER.CATHY]));
 
 		// Alice clues Bob red on slot 3.
 		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 };

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -5,7 +5,7 @@ import { describe, it } from 'node:test';
 
 import { PLAYER, setup } from '../test-utils.js';
 import HGroup from '../../src/conventions/h-group.js';
-import { CLUE } from '../../src/constants.js';
+import { ACTION } from '../../src/constants.js';
 import * as Utils from '../../src/util.js';
 import logger from '../../src/logger.js';
 
@@ -17,32 +17,40 @@ describe('trash chop move', () => {
 	it('will give a rank tcm for 1 card', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['xx', 'xx', 'xx', 'r1', 'b4']
-		]);
+			['r4', 'r4', 'g4', 'r1', 'b4']
+		], 4);
 
 		state.play_stacks = [2, 2, 2, 2, 2];
 
+		logger.setLevel(logger.LEVELS.ERROR);
+
 		const { save_clues } = find_clues(state);
-		assert.deepEqual(save_clues[PLAYER.BOB], { type: CLUE.RANK, value: 1 });
+		const bob_save = save_clues[PLAYER.BOB];
+
+		assert(bob_save !== undefined);
+		assert(bob_save.type === ACTION.RANK && bob_save.value === 1);
 	});
 
 	it('will give a rank tcm touching multiple trash cards', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['xx', 'xx', 'b1', 'r1', 'b4']
-		]);
+			['r4', 'r4', 'b1', 'r1', 'b4']
+		], 4);
 
 		state.play_stacks = [2, 2, 2, 2, 2];
 
 		const { save_clues } = find_clues(state);
-		assert.deepEqual(save_clues[PLAYER.BOB], { type: CLUE.RANK, value: 1 });
+		const bob_save = save_clues[PLAYER.BOB];
+
+		assert(bob_save !== undefined);
+		assert(bob_save.type === ACTION.RANK && bob_save.value === 1);
 	});
 
 	it ('will not give a tcm if chop is trash', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['xx', 'xx', 'b1', 'b4', 'g1']
-		]);
+			['r4', 'r4', 'b1', 'b4', 'g1']
+		], 4);
 
 		state.play_stacks = [2, 2, 2, 2, 2];
 

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -1,0 +1,52 @@
+// @ts-ignore
+import { strict as assert } from 'node:assert';
+// @ts-ignore
+import { describe, it } from 'node:test';
+
+import { PLAYER, setup } from '../test-utils.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { CLUE } from '../../src/constants.js';
+import * as Utils from '../../src/util.js';
+import logger from '../../src/logger.js';
+
+import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+describe('trash chop move', () => {
+	it('will give a rank tcm for 1 card', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['xx', 'xx', 'xx', 'r1', 'b4']
+		]);
+
+		state.play_stacks = [2, 2, 2, 2, 2];
+
+		const { save_clues } = find_clues(state);
+		assert.deepEqual(save_clues[PLAYER.BOB], { type: CLUE.RANK, value: 1 });
+	});
+
+	it('will give a rank tcm touching multiple trash cards', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['xx', 'xx', 'b1', 'r1', 'b4']
+		]);
+
+		state.play_stacks = [2, 2, 2, 2, 2];
+
+		const { save_clues } = find_clues(state);
+		assert.deepEqual(save_clues[PLAYER.BOB], { type: CLUE.RANK, value: 1 });
+	});
+
+	it ('will not give a tcm if chop is trash', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['xx', 'xx', 'b1', 'b4', 'g1']
+		]);
+
+		state.play_stacks = [2, 2, 2, 2, 2];
+
+		const { save_clues } = find_clues(state);
+		assert(save_clues[PLAYER.BOB] === undefined);
+	});
+});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,69 @@
+import { Card } from '../src/basics/Card.js';
+import { State } from '../src/basics/State.js';
+import * as Utils from '../src/util.js';
+
+/** @type {Readonly<{RED: 0, YELLOW: 1, GREEN: 2, BLUE: 3, PURPLE: 4}>} */
+export const COLOUR = Object.freeze({
+	RED: 0,
+	YELLOW: 1,
+	GREEN: 2,
+	BLUE: 3,
+	PURPLE: 4
+});
+
+/** @type {Readonly<{ALICE: 0, BOB: 1, CATHY: 2, DONALD: 3, EMILY: 4}>} */
+export const PLAYER = Object.freeze({
+	ALICE: 0,
+	BOB: 1,
+	CATHY: 2,
+	DONALD: 3,
+	EMILY: 4
+});
+
+/**
+ * @param {typeof State} StateClass
+ * @param {string[][]} hands
+ */
+export function setup(StateClass, hands) {
+	const playerNames = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'].slice(0, hands.length);
+	const suits = ['Red', 'Yellow', 'Green', 'Blue', 'Purple'];
+
+	const state = new StateClass(-1, playerNames, 1, suits);
+	Utils.globalModify({state});
+
+	let orderCounter = 0;
+
+	// Draw all the hands
+	for (let playerIndex = 0; playerIndex < hands.length; playerIndex++) {
+		const hand = hands[playerIndex];
+		for (const short of hand.reverse()) {
+			const card = expandShortCard(short);
+			if (card.suitIndex !== -1) {
+				console.log('EEEEE');
+			}
+			const action = { type: 'draw', order: orderCounter, playerIndex, suitIndex: card.suitIndex, rank: card.rank };
+			orderCounter++;
+
+			state.handle_action(action);
+		}
+	}
+
+	return state;
+}
+
+/**
+ * @param {string} short
+ */
+export function expandShortCard(short) {
+	return {
+		suitIndex: ['x', 'r', 'y', 'g', 'b', 'p'].indexOf(short[0]) - 1,
+		rank: Number(short[1]) || -1
+	};
+}
+
+/**
+ * @param  {Card} card [description]
+ */
+export function getRawInferences(card) {
+	return card.inferred.map(c => Utils.objPick(c, ['suitIndex', 'rank']));
+}

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -24,11 +24,11 @@ export const PLAYER = Object.freeze({
  * @param {typeof State} StateClass
  * @param {string[][]} hands
  */
-export function setup(StateClass, hands) {
+export function setup(StateClass, hands, level) {
 	const playerNames = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'].slice(0, hands.length);
 	const suits = ['Red', 'Yellow', 'Green', 'Blue', 'Purple'];
 
-	const state = new StateClass(-1, playerNames, 1, suits);
+	const state = new StateClass(-1, playerNames, 0, suits, level);
 	Utils.globalModify({state});
 
 	let orderCounter = 0;
@@ -37,11 +37,8 @@ export function setup(StateClass, hands) {
 	for (let playerIndex = 0; playerIndex < hands.length; playerIndex++) {
 		const hand = hands[playerIndex];
 		for (const short of hand.reverse()) {
-			const card = expandShortCard(short);
-			if (card.suitIndex !== -1) {
-				console.log('EEEEE');
-			}
-			const action = { type: 'draw', order: orderCounter, playerIndex, suitIndex: card.suitIndex, rank: card.rank };
+			const { suitIndex, rank } = expandShortCard(short);
+			const action = { type: 'draw', order: orderCounter, playerIndex, suitIndex, rank };
 			orderCounter++;
 
 			state.handle_action(action);


### PR DESCRIPTION
The bot no longer incorrectly requires the rightmost touched card of a *Trash Chop Move* to be the focus of the clue.