### PR TITLE
Improve management of multiple bots (+ assorted fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ It follows [H-Group](https://hanabi.github.io/) conventions. The goal of the bot
 https://user-images.githubusercontent.com/25177576/190633432-57b527da-786e-4c24-92d0-e1d01291986e.mp4
 
 ## Bot features
-- Can play at different levels of the H-Group convention set (currently, levels 1-4 are supported).
+- Can play at different levels of the H-Group convention set. Currently, levels 1-4 are supported.
 - Takes notes during the game on cards in its own hand.
-- Internally rewinds to relevant turns  to understand mistakes.
-- Can create and start games on its own (to play bot-only games, or to control it remotely).
+- Internally rewinds to relevant turns to understand mistakes.
+- Can create and start games on its own (i.e. for playing bot-only games).
 
 ## Running locally
 - You'll need to have NodeJS v16 or above. You can download it [here](https://nodejs.org/en/download/).
@@ -30,5 +30,6 @@ Send a PM to the bot on hanab.live (`/pm <HANABI_USERNAME> <message>`) to intera
 - `/create <name> <maxPlayers> <password>` to have the bot create a table. The name can't have spaces.
 - `/start` to have the bot start the game (only works if it created the table).
 - `/settings [conventions='HGroup'] [level]` to set or view the bot's conventions and level. The bot plays with H-Group conventions at level 1 by default.
+- `/restart` and `remake` to perform the corresponding actions in the current room after the game has finished.
 
 Feel free to report any issues [here](https://github.com/WillFlame14/hanabi-bot/issues)!

--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -73,7 +73,7 @@ export function handle_action(action, catchup = false) {
 			//  { type: 'turn', num: 1, currentPlayerIndex: 1 }
 			const { currentPlayerIndex } = action;
 			if (currentPlayerIndex === this.ourPlayerIndex && !catchup) {
-				setTimeout(() => this.take_action(this), 2000);
+				setTimeout(() => Utils.sendCmd('action', this.take_action(this)), 2000);
 
 				// Update notes on cards
 				for (const card of this.hands[this.ourPlayerIndex]) {

--- a/src/basics/hanabi-util.js
+++ b/src/basics/hanabi-util.js
@@ -61,11 +61,11 @@ export function isBasicTrash(state, suitIndex, rank) {
  * @param {number} inferringPlayerIndex     The inferring player (i.e. can only infer on their own cards).
  * @param {number} suitIndex
  * @param {number} rank
- * @param {FindOptions} [options]
+ * @param {FindOptions & {ignoreCM?: boolean}} [options]
  */
-export function isSaved(state, inferringPlayerIndex, suitIndex, rank, order = -1, options) {
+export function isSaved(state, inferringPlayerIndex, suitIndex, rank, order = -1, options = {}) {
 	return visibleFind(state, inferringPlayerIndex, suitIndex, rank, options).some(c => {
-		return c.order !== order && (c.finessed || c.clued || c.chop_moved);
+		return c.order !== order && (c.finessed || c.clued || (options.ignoreCM ? false : c.chop_moved));
 	});
 }
 

--- a/src/command-handler.js
+++ b/src/command-handler.js
@@ -33,7 +33,7 @@ export const handle = {
 			if (data.msg.startsWith('/join')) {
 				// Find the table with the user that invited us
 				for (const table of Object.values(tables)) {
-					if (!table.sharedReplay && table.players.includes(data.who)) {
+					if (!table.sharedReplay && (table.players.includes(data.who) || table.spectators.some(spec => spec.name === data.who))) {
 						if (table.running || table.players.length === 6) {
 							continue;
 						}
@@ -52,7 +52,7 @@ export const handle = {
 			else if (data.msg.startsWith('/rejoin')) {
 				// Find the table with the user that invited us
 				for (const table of Object.values(tables)) {
-					if (!table.sharedReplay && table.players.includes(data.who)) {
+					if (table && !table.sharedReplay && (table.players.includes(data.who) || table.spectators.some(spec => spec.name === data.who))) {
 						if (!table.players.includes(self.username)) {
 							Utils.sendChat(data.who, 'Could not join, as the bot was never a player in this room.');
 							return;
@@ -79,6 +79,14 @@ export const handle = {
 			// Starts the game (format: /start)
 			else if (data.msg.startsWith('/start')) {
 				Utils.sendCmd('tableStart', { tableID: state.tableID });
+			}
+			// Restarts a game (format: /restart)
+			else if (data.msg.startsWith('/restart')) {
+				Utils.sendCmd('tableRestart', { tableID: state.tableID, hidePregame: true });
+			}
+			// Remakes a table (format: /remake)
+			else if (data.msg.startsWith('/remake')) {
+				Utils.sendCmd('tableRestart', { tableID: state.tableID, hidePregame: false });
 			}
 			// Displays or modifies the current settings (format: /settings [convention = 'HGroup'] [level = 1])
 			else if (data.msg.startsWith('/settings')) {
@@ -131,7 +139,7 @@ export const handle = {
 
 		// If we are going first, we need to take an action now
 		if (state.ourPlayerIndex === 0 && state.turn_count === 0) {
-			setTimeout(() => state.take_action(state), 3000);
+			setTimeout(() => Utils.sendCmd('action', state.take_action(state)), 3000);
 		}
 	},
 	joined: (data) => {

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -12,6 +12,7 @@ import * as Utils from '../../util.js';
  * @typedef {import('../../types.js').Clue} Clue
  * @typedef {import('../../types.js').FixClue} FixClue
  * @typedef {import('../../types.js').PerformAction} PerformAction
+ * @typedef {import('../../types.js').Action} Action
  */
 
 /**
@@ -156,6 +157,7 @@ function find_play_over_save(state, target, all_play_clues, locked = false) {
  * @param {Clue[][]} play_clues
  * @param {Clue[]} save_clues
  * @param {FixClue[][]} fix_clues
+ * @returns {(Action & {value?: number})}[][]}
  */
 export function find_urgent_actions(state, play_clues, save_clues, fix_clues) {
 	const urgent_actions = [[], [], [], [], [], [], [], [], []];

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -86,17 +86,15 @@ function find_tcm(state, target, saved_cards, trash_card) {
 
 	// Colour or rank save (if possible) is preferred over trash chop move
 	// TODO: Can save variant cards together (like rainbow)
-	if (isCritical(state, chop.suitIndex, chop.rank) &&
+	if ((isCritical(state, chop.suitIndex, chop.rank) || save2(state, target, chop)) &&
 		(saved_cards.every(c => c.suitIndex === chop.suitIndex) || saved_cards.every(c => c.rank === chop.rank))
 	) {
 		logger.info('prefer direct save');
 		return;
 	}
-	else if (save2(state, target, chop) && saved_cards.every(c => c.rank === 2)) {
-		logger.info('prefer direct 2 save');
-		return;
-	}
-	else if (isTrash(state, state.ourPlayerIndex, chop.suitIndex, chop.rank, chop.order)) {
+	else if (isTrash(state, state.ourPlayerIndex, chop.suitIndex, chop.rank, chop.order) ||
+		saved_cards.some(c => c.matches(chop.suitIndex, chop.rank) && c.order !== chop.order)	// A duplicated card is also trash
+	) {
 		logger.info('chop is trash, can give tcm later');
 		return;
 	}

--- a/src/conventions/h-group/clue-finder/fix-clues.js
+++ b/src/conventions/h-group/clue-finder/fix-clues.js
@@ -65,7 +65,7 @@ export function find_fix_clues(state, play_clues, save_clues, options = {}) {
 
 				// We don't need to fix duplicated cards where we hold one copy, since we can just sarcastic discard
 				const unknown_duplicated = card.clued && card.inferred.length > 1 &&
-					isSaved(state, state.ourPlayerIndex, card.suitIndex, card.rank, card.order, { ignore: [state.ourPlayerIndex] });
+					isSaved(state, state.ourPlayerIndex, card.suitIndex, card.rank, card.order, { ignore: [state.ourPlayerIndex], ignoreCM: true });
 
 				let fix_criteria;
 				if (wrong_inference) {

--- a/src/conventions/h-group/clue-finder/stall-clues.js
+++ b/src/conventions/h-group/clue-finder/stall-clues.js
@@ -3,9 +3,7 @@ import logger from '../../../logger.js';
 
 /**
  * @typedef {import('../../h-group.js').default} State
- * @typedef {import('../../../basics/Card.js').Card} Card
  * @typedef {import('../../../types.js').Clue} Clue
- * @typedef {import('../../../types.js').FixClue} FixClue
  */
 
 /**
@@ -27,14 +25,12 @@ export function find_stall_clue(state, severity, tempo_clue) {
 		}
 
 		const hand = state.hands[target];
-		console.log(severity);
 
 		// Early game
 		if (severity > 0) {
 			// 5 Stall (priority 0)
 			if (hand.some(c => c.rank === 5 && !c.clued && state.max_ranks[c.suitIndex] >= 5)) {
 				const c = hand.find(c => c.rank === 5 && !c.clued && state.max_ranks[c.suitIndex] >= 5);
-				console.log(state.max_ranks, c.suitIndex);
 				stall_clues[0].push({ type: ACTION.RANK, target, value: 5 });
 				break;
 			}

--- a/src/conventions/h-group/clue-finder/stall-clues.js
+++ b/src/conventions/h-group/clue-finder/stall-clues.js
@@ -2,7 +2,17 @@ import { ACTION } from '../../../constants.js';
 import logger from '../../../logger.js';
 
 /**
+ * @typedef {import('../../h-group.js').default} State
+ * @typedef {import('../../../basics/Card.js').Card} Card
+ * @typedef {import('../../../types.js').Clue} Clue
+ * @typedef {import('../../../types.js').FixClue} FixClue
+ */
+
+/**
  * Finds a stall clue to give. Always finds a clue if severity is greater than 1 (hard burn).
+ * @param {State} state
+ * @param {number} severity
+ * @param {Clue} tempo_clue
  */
 export function find_stall_clue(state, severity, tempo_clue) {
 	const stall_clues = [[], [], [], []];
@@ -17,11 +27,14 @@ export function find_stall_clue(state, severity, tempo_clue) {
 		}
 
 		const hand = state.hands[target];
+		console.log(severity);
 
 		// Early game
 		if (severity > 0) {
 			// 5 Stall (priority 0)
 			if (hand.some(c => c.rank === 5 && !c.clued && state.max_ranks[c.suitIndex] >= 5)) {
+				const c = hand.find(c => c.rank === 5 && !c.clued && state.max_ranks[c.suitIndex] >= 5);
+				console.log(state.max_ranks, c.suitIndex);
 				stall_clues[0].push({ type: ACTION.RANK, target, value: 5 });
 				break;
 			}

--- a/src/conventions/h-group/clue-finder/stall-clues.js
+++ b/src/conventions/h-group/clue-finder/stall-clues.js
@@ -21,7 +21,7 @@ export function find_stall_clue(state, severity, tempo_clue) {
 		// Early game
 		if (severity > 0) {
 			// 5 Stall (priority 0)
-			if (hand.some(c => c.rank === 5 && !c.clued)) {
+			if (hand.some(c => c.rank === 5 && !c.clued && state.max_ranks[c.suitIndex] >= 5)) {
 				stall_clues[0].push({ type: ACTION.RANK, target, value: 5 });
 				break;
 			}

--- a/src/conventions/h-group/clue-interpretation/interpret-stall.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-stall.js
@@ -101,8 +101,8 @@ export function stalling_situation(state, action) {
 
 		// Only early game 5 stall exists before level 9
 		if (state.level < LEVEL.STALLING && severity !== 1) {
-			logger.warn('ignoring possible stall found before level 9');
-			return false;
+			logger.warn('stall found before level 9');
+			// return false;
 		}
 
 		return true;

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -28,8 +28,7 @@ export function take_action(state) {
 
 	// Unlock next player
 	if (urgent_actions[0].length > 0) {
-		Utils.sendCmd('action', urgent_actions[0][0]);
-		return;
+		return urgent_actions[0][0];
 	}
 
 	// Urgent save for next player
@@ -37,8 +36,7 @@ export function take_action(state) {
 		for (let i = 1; i < 4; i++) {
 			const actions = urgent_actions[i];
 			if (actions.length > 0) {
-				Utils.sendCmd('action', actions[0]);
-				return;
+				return actions[0];
 			}
 		}
 	}
@@ -74,8 +72,7 @@ export function take_action(state) {
 		({ card: best_playable_card, priority } = determine_playable_card(state, playable_cards));
 
 		if (priority === 0) {
-			Utils.sendCmd('action', { tableID, type: ACTION.PLAY, target: best_playable_card.order });
-			return;
+			return { tableID, type: ACTION.PLAY, target: best_playable_card.order };
 		}
 	}
 
@@ -87,21 +84,18 @@ export function take_action(state) {
 
 		if (best_play_clue?.result.finesses > 0) {
 			const { type, target, value } = best_play_clue;
-			Utils.sendCmd('action', { tableID, type, target, value });
-			return;
+			return { tableID, type, target, value };
 		}
 	}
 
 	// Sarcastic discard to someone else
 	if (state.level >= LEVEL.SARCASTIC && discards.length > 0) {
-		Utils.sendCmd('action', { tableID, type: ACTION.DISCARD, target: discards[0].order });
-		return;
+		return { tableID, type: ACTION.DISCARD, target: discards[0].order };
 	}
 
 	// Unlock other player than next
 	if (urgent_actions[4].length > 0) {
-		Utils.sendCmd('action', urgent_actions[4][0]);
-		return;
+		return urgent_actions[4][0];
 	}
 
 	// Forced discard if next player is locked without a playable or trash card
@@ -109,25 +103,21 @@ export function take_action(state) {
 	const nextPlayerIndex = (state.ourPlayerIndex + 1) % state.numPlayers;
 	if (state.clue_tokens === 0 && state.hands[nextPlayerIndex].isLocked() && !handLoaded(state, nextPlayerIndex)) {
 		discard_chop(hand, tableID);
-		return;
 	}
 
 	// Playing a connecting card or playing a 5
 	if (playable_cards.length > 0 && priority <= 3) {
-		Utils.sendCmd('action', { tableID, type: ACTION.PLAY, target: best_playable_card.order });
-		return;
+		return { tableID, type: ACTION.PLAY, target: best_playable_card.order };
 	}
 
 	// Discard known trash at high pace, low clues
 	if (trash_cards.length > 0 && getPace(state) > state.numPlayers * 2 && state.clue_tokens <= 3) {
-		Utils.sendCmd('action', { tableID, type: ACTION.DISCARD, target: trash_cards[0].order });
-		return;
+		return { tableID, type: ACTION.DISCARD, target: trash_cards[0].order };
 	}
 
 	// Playable card with any priority
 	if (playable_cards.length > 0) {
-		Utils.sendCmd('action', { tableID, type: ACTION.PLAY, target: best_playable_card.order });
-		return;
+		return { tableID, type: ACTION.PLAY, target: best_playable_card.order };
 	}
 
 	if (state.clue_tokens > 0) {
@@ -140,8 +130,7 @@ export function take_action(state) {
 
 				if (clue_value >= minimum_clue_value) {
 					const { type, target, value } = best_play_clue;
-					Utils.sendCmd('action', { tableID, type, target, value });
-					return;
+					return { tableID, type, target, value };
 				}
 				else {
 					logger.info('clue too low value', Utils.logClue(best_play_clue), clue_value);
@@ -150,43 +139,39 @@ export function take_action(state) {
 
 			// Go through rest of actions in order of priority (except early save)
 			if (i !== 8 && urgent_actions[i].length > 0) {
-				Utils.sendCmd('action', urgent_actions[i][0]);
-				return;
+				return urgent_actions[i][0];
 			}
 		}
 	}
 
 	// Either there are no clue tokens or the best play clue doesn't meet MCVP
 
-	const endgame_stall = inEndgame(state) && state.clue_tokens > 0 &&
-		state.hypo_stacks.some((stack, index) => stack > state.play_stacks[index]);
+	// TODO: Reconsider endgame stall
+	// const endgame_stall = inEndgame(state) && state.clue_tokens > 0 &&
+	// 	state.hypo_stacks.some((stack, index) => stack > state.play_stacks[index]);
 
-	// 8 clues or endgame
-	if (state.clue_tokens === 8 || endgame_stall) {
+	// 8 clues or endgame (currently disabled)
+	if (state.clue_tokens === 8) {
 		const { type, value, target } = find_stall_clue(state, 4, best_play_clue);
 
 		// Should always be able to find a clue, even if it's a hard burn
-		Utils.sendCmd('action', { tableID, type, target, value });
-		return;
+		return { tableID, type, target, value };
 	}
 
 	// Discard known trash (no pace requirement)
 	if (trash_cards.length > 0) {
-		Utils.sendCmd('action', { tableID, type: ACTION.DISCARD, target: trash_cards[0].order });
-		return;
+		return { tableID, type: ACTION.DISCARD, target: trash_cards[0].order };
 	}
 
 	// Early save
 	if (state.clue_tokens > 0 && urgent_actions[8].length > 0) {
-		Utils.sendCmd('action', urgent_actions[8][0]);
-		return;
+		return urgent_actions[8][0];
 	}
 
 	// Locked hand and no good clues to give
 	if (state.hands[state.ourPlayerIndex].isLocked() && state.clue_tokens > 0) {
 		const { type, value, target } = find_stall_clue(state, 3, best_play_clue);
-		Utils.sendCmd('action', { tableID, type, target, value });
-		return;
+		return { tableID, type, target, value };
 	}
 
 	// Early game
@@ -195,12 +180,11 @@ export function take_action(state) {
 
 		if (clue !== undefined) {
 			const { type, value, target } = clue;
-			Utils.sendCmd('action', { tableID, type, target, value });
-			return;
+			return { tableID, type, target, value };
 		}
 	}
 
-	discard_chop(hand, tableID);
+	return discard_chop(hand, tableID);
 }
 
 /**
@@ -221,5 +205,5 @@ function discard_chop(hand, tableID) {
 		discard = hand[Math.floor(Math.random() * hand.length)];
 	}
 
-	Utils.sendCmd('action', { tableID, type: ACTION.DISCARD, target: discard.order });
+	return { tableID, type: ACTION.DISCARD, target: discard.order };
 }

--- a/test/h-group/level-1.js
+++ b/test/h-group/level-1.js
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 // @ts-ignore
 import { describe, it } from 'node:test';
 
+import { ACTION } from '../../src/constants.js';
 import { COLOUR, PLAYER, setup, getRawInferences, expandShortCard } from '../test-utils.js';
 import HGroup from '../../src/conventions/h-group.js';
 import { CLUE } from '../../src/constants.js';
@@ -113,5 +114,20 @@ describe('play clue', () => {
 		// Bob's slot 1 should be inferred as r2.
 		const targetCard = state.hands[PLAYER.BOB][0];
 		assert.deepEqual(getRawInferences(targetCard), ['r2'].map(expandShortCard));
+	});
+});
+
+describe('early game', () => {
+	it('will not 5 stall on a trash 5', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g4', 'r5', 'r4', 'y4', 'b3'],
+		]);
+
+		// Discarded both r4's
+		state.discard_stacks[0][3] = 2;
+
+		const action = state.take_action(state);
+		assert.deepEqual(action, { type: ACTION.DISCARD, target: 0 });
 	});
 });

--- a/test/h-group/level-1.js
+++ b/test/h-group/level-1.js
@@ -125,9 +125,10 @@ describe('early game', () => {
 		]);
 
 		// Discarded both r4's
-		state.discard_stacks[0][3] = 2;
+		state.max_ranks[0] = 3;
+		state.clue_tokens = 7;
 
 		const action = state.take_action(state);
-		assert.deepEqual(action, { type: ACTION.DISCARD, target: 0 });
+		assert.deepEqual(Utils.objPick(action, ['type', 'target']), { type: ACTION.DISCARD, target: 0 });
 	});
 });

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -10,6 +10,7 @@ import * as Utils from '../../src/util.js';
 import logger from '../../src/logger.js';
 
 import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
+import { find_urgent_actions } from '../../src/conventions/h-group/action-helper.js';
 
 logger.setLevel(logger.LEVELS.ERROR);
 
@@ -46,7 +47,7 @@ describe('trash chop move', () => {
 		assert(bob_save.type === ACTION.RANK && bob_save.value === 1);
 	});
 
-	it ('will not give a tcm if chop is trash', () => {
+	it('will not give a tcm if chop is trash', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r4', 'r4', 'b1', 'b4', 'g1']
@@ -55,6 +56,56 @@ describe('trash chop move', () => {
 		state.play_stacks = [2, 2, 2, 2, 2];
 
 		const { save_clues } = find_clues(state);
-		assert(save_clues[PLAYER.BOB] === undefined);
+		assert.equal(save_clues[PLAYER.BOB], undefined);
+	});
+
+	it('will not give a tcm if chop is a duplicated card', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'r4', 'b1', 'g4', 'g4']
+		], 4);
+
+		state.play_stacks = [2, 2, 2, 2, 2];
+
+		const { save_clues } = find_clues(state);
+		assert.equal(save_clues[PLAYER.BOB], undefined);
+	});
+
+	it('will not give a tcm if chop can be saved directly (critical)', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'r4', 'b1', 'r1', 'g5']
+		], 4);
+
+		state.play_stacks = [2, 2, 2, 2, 2];
+
+		const { save_clues } = find_clues(state);
+		assert.deepEqual(Utils.objPick(save_clues[PLAYER.BOB], ['type', 'value']), { type: ACTION.RANK, value: 5 });
+	});
+
+	it('will not give a tcm if chop can be saved directly (2 save)', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y4', 'g4', 'b1', 'r1', 'y2']
+		], 4);
+
+		state.play_stacks = [5, 0, 0, 2, 2];
+
+		const { save_clues } = find_clues(state);
+		assert.deepEqual(Utils.objPick(save_clues[PLAYER.BOB], ['type', 'value']), { type: ACTION.RANK, value: 2 });
+	});
+
+	it('will not give a tcm if a play can be given instead', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y4', 'g4', 'b1', 'r1', 'y2']
+		], 4);
+
+		state.play_stacks = [5, 1, 0, 2, 2];
+
+		const { play_clues, save_clues, fix_clues } = find_clues(state);
+		const urgent_actions = find_urgent_actions(state, play_clues, save_clues, fix_clues);
+		assert.equal(urgent_actions[1], undefined);
+		assert.deepEqual(Utils.objPick(urgent_actions[2][0], ['type', 'value']), { type: ACTION.COLOUR, value: 1 });
 	});
 });

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -105,7 +105,7 @@ describe('trash chop move', () => {
 
 		const { play_clues, save_clues, fix_clues } = find_clues(state);
 		const urgent_actions = find_urgent_actions(state, play_clues, save_clues, fix_clues);
-		assert.equal(urgent_actions[1], undefined);
+		assert.deepEqual(urgent_actions[1], []);
 		assert.deepEqual(Utils.objPick(urgent_actions[2][0], ['type', 'value']), { type: ACTION.COLOUR, value: 1 });
 	});
 });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -21,8 +21,10 @@ export const PLAYER = Object.freeze({
 });
 
 /**
- * @param {typeof State} StateClass
+ * @template {State} A
+ * @param {{new(...args: any[]): A}} StateClass
  * @param {string[][]} hands
+ * @return {A}
  */
 export function setup(StateClass, hands, level) {
 	const playerNames = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'].slice(0, hands.length);


### PR DESCRIPTION
- New `/restart` and `/remake` commands.
- Spectators can now invite bots to their room.
- Re-enabled stalling before level 9.
- Several other minor fixes and tests.