### PR TITLE
Improve save clues (also general types)

### DIFF
--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -1,6 +1,5 @@
 import { CLUE } from'./constants.js';
 import { Card } from'./basics/Card.js';
-import { good_touch_elim, update_hypo_stacks } from'./basics/helper.js';
 import logger from'./logger.js';
 import * as Basics from'./basics.js';
 import * as Utils from'./util.js';
@@ -37,7 +36,7 @@ export function handle_action(action, catchup = false) {
 			}
 			logger.warn(`${playerName} clues ${clue_value} to ${targetName}`);
 
-			this.interpret_clue(this, /** @type {ClueAction} */ (action));
+			this.interpret_clue(this, action);
 			this.last_actions[giver] = action;
 
 			// Remove the newly_clued flag
@@ -57,14 +56,14 @@ export function handle_action(action, catchup = false) {
 			Object.assign(card, {suitIndex, rank});
 			logger.warn(`${playerName} ${failed ? 'bombs' : 'discards'} ${Utils.logCard(card)}`);
 
-			Basics.onDiscard(this, /** @type {DiscardAction} */ (action));
-			this.interpret_discard(this, /** @type {DiscardAction} */ (action), card);
+			Basics.onDiscard(this, action);
+			this.interpret_discard(this, action, card);
 			this.last_actions[playerIndex] = action;
 			break;
 		}
 		case 'draw': {
 			// { type: 'draw', playerIndex: 0, order: 2, suitIndex: 1, rank: 2 },
-			Basics.onDraw(this, /** @type {CardAction} */ (action));
+			Basics.onDraw(this, action);
 			break;
 		}
 		case 'gameOver':
@@ -97,7 +96,7 @@ export function handle_action(action, catchup = false) {
 			Object.assign(card, {suitIndex, rank});
 			logger.warn(`${playerName} plays ${Utils.logCard(card)}`);
 
-			this.interpret_play(this, /** @type {PlayAction} */ (action));
+			this.interpret_play(this, action);
 			this.last_actions[playerIndex] = action;
 			break;
 		}

--- a/src/basics/Card.js
+++ b/src/basics/Card.js
@@ -1,8 +1,8 @@
 /**
  * @typedef {{symmetric?: boolean, infer?: boolean}} MatchOptions
- * @typedef {import('./../types.js').Clue} Clue
- * 
- * @typedef {{suitIndex: number, rank: number}} BasicCard
+ * @typedef {import('../types.js').BaseClue} BaseClue
+ * @typedef {import('../types.js').Clue} Clue
+ * @typedef {import('../types.js').BasicCard} BasicCard
  */
 
 /**
@@ -13,7 +13,7 @@ export class Card {
 	rank = -1;			// The rank of the card
 	order = -1;			// The ordinal number of the card
 
-	clues = /** @type {Omit<Clue, 'target'>[]} */ ([]);			// List of clues that have touched this card
+	clues = /** @type {BaseClue[]} */ ([]);			// List of clues that have touched this card
 	possible = /** @type {Card[]} */ ([]);						// All possibilities of the card (from positive/negative information)
 	inferred = /** @type {Card[]} */ ([]);						// All inferences of the card (from conventions)
 	old_inferred = /** @type {Card[] | undefined} */ (undefined);		// Only used when undoing a finesse

--- a/src/basics/Hand.js
+++ b/src/basics/Hand.js
@@ -4,6 +4,7 @@ import logger from '../logger.js';
 /**
  * @typedef {import('./Card.js').Card} Card
  * @typedef {import('./Card.js').MatchOptions} MatchOptions
+ * @typedef {import('../types.js').BaseClue} BaseClue
  * @typedef {import('../types.js').Clue} Clue
  */
 
@@ -57,7 +58,7 @@ export class Hand extends Array {
 	/**
 	 * Returns an array of cards touched by the clue.
      * @param {string[]} suits
-     * @param {Omit<Clue, 'target'>} clue
+     * @param {BaseClue} clue
      */
 	clueTouched(suits, clue) {
 		return this.filter(card => cardTouched(card, suits, clue));

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -169,11 +169,11 @@ export class State {
 		logger.setLevel(logger.LEVELS.INFO);
 
 		// Rewrite and save as a rewind action
-		const known_action = { type: 'rewind', order, playerIndex, suitIndex, rank };
+		const known_action = Object.freeze({ type: 'rewind', order, playerIndex, suitIndex, rank });
 		new_state.handle_action(known_action, true);
 		logger.warn('Rewriting order', order, 'to', Utils.logCard({suitIndex, rank}));
 
-		const pivotal_action = this.actionList[action_index];
+		const pivotal_action = /** @type {ClueAction} */ (this.actionList[action_index]);
 		pivotal_action.mistake = finessed || this.rewindDepth > 1;
 		logger.info('pivotal action', pivotal_action);
 		new_state.handle_action(pivotal_action, true);
@@ -201,7 +201,7 @@ export class State {
 	 * 
 	 * The 'enableLogs' option causes all logs from the simulated state to be printed.
 	 * Otherwise, only errors are printed from the simulated state.
-     * @param {Omit<ClueAction, 'type'>} action
+     * @param {ClueAction} action
      * @param {{simulatePlayerIndex?: number, enableLogs?: boolean}} options
      */
 	simulate_clue(action, options = {}) {

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -169,8 +169,7 @@ export class State {
 		logger.setLevel(logger.LEVELS.INFO);
 
 		// Rewrite and save as a rewind action
-		const known_action = Object.freeze({ type: 'rewind', order, playerIndex, suitIndex, rank });
-		new_state.handle_action(known_action, true);
+		new_state.handle_action({ type: 'rewind', order, playerIndex, suitIndex, rank }, true);
 		logger.warn('Rewriting order', order, 'to', Utils.logCard({suitIndex, rank}));
 
 		const pivotal_action = /** @type {ClueAction} */ (this.actionList[action_index]);

--- a/src/basics/helper.js
+++ b/src/basics/helper.js
@@ -7,11 +7,13 @@ import * as Utils from '../util.js';
  * @typedef {import('./State.js').State} State
  * @typedef {import('./Hand.js').Hand} Hand
  * @typedef {import('./Card.js').Card} Card
+ * @typedef {import('../types.js').BaseClue} BaseClue
  * @typedef {import('../types.js').Clue} Clue
+ * @typedef {import('../types.js').BasicCard} BasicCard
  */
 
 /**
- * @param {Omit<Clue, 'target'>} clue
+ * @param {BaseClue} clue
  * @param {string[]} suits
  */
 export function find_possibilities(clue, suits) {
@@ -32,7 +34,7 @@ export function find_possibilities(clue, suits) {
  * @param {State} state
  * @param {number} giver
  * @param {number} target
- * @param {{suitIndex: number, rank: number}[]} prev_found	All previously found bad touch possibiltiies.
+ * @param {BasicCard[]} prev_found	All previously found bad touch possibiltiies.
  */
 export function bad_touch_possiblities(state, giver, target, prev_found = []) {
 	const bad_touch = prev_found;
@@ -169,7 +171,8 @@ export function handLoaded(state, target) {
 
 /**
  * @param {Hand} hand
- * @param {{suitIndex: number, rank: number}[]} cards
+ * @param {BasicCard[]} cards
+ * @param {{ignore?: number[], hard?: boolean}} options
  */
 export function good_touch_elim(hand, cards, options = {}) {
 	for (const card of hand) {

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -193,7 +193,7 @@ export function order_1s(state, cards) {
  * @param {Clue[]} save_clues
  * @param {FixClue[][]} fix_clues
  * @param {Card[][]} playable_priorities
- * @returns {(Action & {value?: number})}[][]}
+ * @returns {PerformAction[][]}
  */
 export function find_urgent_actions(state, play_clues, save_clues, fix_clues, playable_priorities) {
 	const urgent_actions = [[], [], [], [], [], [], [], [], []];
@@ -359,25 +359,6 @@ export function determine_playable_card(state, playable_cards) {
 
 		// Unknown card
 		if (possibilities.length > 1) {
-			// if (state.level >= 3 && card.clues.every(clue => clue.type === CLUE.RANK && clue.value === 1)) {
-			// 	// Fresh 1's
-			// 	if (card.order >= (state.numPlayers * state.hands[0].length)) {
-			// 		priorities[4].push(card);
-			// 		fresh_1s++;
-			// 	}
-			// 	// Starting hand 1's
-			// 	else {
-			// 		// Chop focus
-			// 		if (card.order === state.hands[state.ourPlayerIndex][find_chop(state.hands[state.ourPlayerIndex])].order) {
-			// 			priorities[4].unshift(card);
-			// 		}
-			// 		else {
-			// 			// Otherwise, right to left but after fresh 1s
-			// 			priorities[4].splice(fresh_1s, 0, card);
-			// 		}
-			// 	}
-			// 	continue;
-			// }
 			priorities[4].push(card);
 			continue;
 		}

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -22,9 +22,9 @@ import * as Utils from '../../util.js';
  * A clue must have value >= 1 to meet Minimum Clue Value Principle (MCVP).
  * @param {ClueResult} clue_result
  */
-function find_clue_value(clue_result) {
-	const { finesses, new_touched, playables, bad_touch, elim } = clue_result;
-	return finesses + 0.5*((new_touched - bad_touch) + playables.length) + 0.01*elim - 1.5*bad_touch;
+export function find_clue_value(clue_result) {
+	const { finesses, new_touched, playables, bad_touch, elim, remainder } = clue_result;
+	return finesses + 0.5*((new_touched - bad_touch) + playables.length) + 0.01*elim - 1.5*bad_touch - 0.5*remainder;
 }
 
 /**

--- a/src/conventions/h-group/clue-finder/clue-safe.js
+++ b/src/conventions/h-group/clue-finder/clue-safe.js
@@ -21,8 +21,7 @@ export function clue_safe(state, clue) {
 	const { target } = clue;
 
 	const list = state.hands[target].clueTouched(state.suits, clue).map(c => c.order);
-	const action = Object.freeze({ type: 'clue', giver: state.ourPlayerIndex, target, list, clue });
-	const hypo_state = state.simulate_clue(action);//, { simulatePlayerIndex: target });
+	const hypo_state = state.simulate_clue({ type: 'clue', giver: state.ourPlayerIndex, target, list, clue });	//, { simulatePlayerIndex: target });
 
 	const nextPlayerIndex = (state.ourPlayerIndex + 1) % state.numPlayers;
 	const hand = hypo_state.hands[nextPlayerIndex];

--- a/src/conventions/h-group/clue-finder/clue-safe.js
+++ b/src/conventions/h-group/clue-finder/clue-safe.js
@@ -9,6 +9,7 @@ import * as Utils from '../../../util.js';
  * @typedef {import('../../h-group.js').default} State
  * @typedef {import('../../../basics/Card.js').Card} Card
  * @typedef {import('../../../types.js').Clue} Clue
+ * @typedef {import('../../../types.js').BasicCard} BasicCard
  */
 
 /**
@@ -20,7 +21,7 @@ export function clue_safe(state, clue) {
 	const { target } = clue;
 
 	const list = state.hands[target].clueTouched(state.suits, clue).map(c => c.order);
-	const action = { type: 'clue', giver: state.ourPlayerIndex, target, list, clue };
+	const action = Object.freeze({ type: 'clue', giver: state.ourPlayerIndex, target, list, clue });
 	const hypo_state = state.simulate_clue(action);//, { simulatePlayerIndex: target });
 
 	const nextPlayerIndex = (state.ourPlayerIndex + 1) % state.numPlayers;
@@ -58,7 +59,7 @@ export function clue_safe(state, clue) {
 /**
  * Returns whether a card is a unique 2 on the board, according to us.
  * @param  {State} state
- * @param  {{ suitIndex: number, rank: number }} card
+ * @param  {BasicCard} card
  */
 function unique2(state, card) {
 	const { suitIndex, rank } = card;
@@ -72,7 +73,7 @@ function unique2(state, card) {
  * Returns the relative "value" of a card. 0 is worthless, 5 is critical.
  * TODO: Improve general algorithm. (e.g. having clued cards of a suit makes it better, a dead suit is worse)
  * @param  {State} state
- * @param  {{ suitIndex: number, rank: number }} card
+ * @param  {BasicCard} card
  */
 export function card_value(state, card) {
 	const { suitIndex, rank } = card;
@@ -97,7 +98,7 @@ export function card_value(state, card) {
  * Checks if the card is a valid (and safe) 2 save.
  * @param {State} state
  * @param {number} target 	The player with the card
- * @param {{ suitIndex: number, rank: number }} card
+ * @param {BasicCard} card
  */
 export function save2(state, target, card) {
 	if (card.rank !== 2) {

--- a/src/conventions/h-group/clue-finder/clue-safe.js
+++ b/src/conventions/h-group/clue-finder/clue-safe.js
@@ -1,13 +1,20 @@
+import { CLUE } from '../../../constants.js';
 import { find_chop } from '../hanabi-logic.js';
 import { handLoaded } from '../../../basics/helper.js';
-import { isCritical } from '../../../basics/hanabi-util.js';
+import { isCritical, isTrash, visibleFind } from '../../../basics/hanabi-util.js';
 import logger from '../../../logger.js';
 import * as Utils from '../../../util.js';
 
 /**
+ * @typedef {import('../../h-group.js').default} State
+ * @typedef {import('../../../basics/Card.js').Card} Card
+ * @typedef {import('../../../types.js').Clue} Clue
+ */
+
+/**
  * Determines if the clue is safe to give (i.e. doesn't put a critical on chop with nothing to do)
- * @param {import('../../h-group.js').default} state
- * @param {import('../../../types.js').Clue} clue
+ * @param {State} state
+ * @param {Clue} clue
  */
 export function clue_safe(state, clue) {
 	const { target } = clue;
@@ -26,12 +33,7 @@ export function clue_safe(state, clue) {
 
 	// Note that chop will be undefined if the entire hand is clued
 	const chop = hand[find_chop(hand, { includeNew: true })];
-	if (chop === undefined) {
-		logger.debug('no chop after clue');
-	}
-	else {
-		logger.debug(`chop after clue is ${Utils.logCard(chop)}`);
-	}
+	logger.debug(chop ? `chop after clue is ${Utils.logCard(chop)}` : 'no chop after clue');
 
 	let give_clue = true;
 
@@ -51,4 +53,57 @@ export function clue_safe(state, clue) {
 	}
 
 	return give_clue;
+}
+
+/**
+ * Returns whether a card is a unique 2 on the board, according to us.
+ * @param  {State} state
+ * @param  {{ suitIndex: number, rank: number }} card
+ */
+function unique2(state, card) {
+	const { suitIndex, rank } = card;
+
+	return state.play_stacks[suitIndex] === 0 &&													// play stack at 0
+		visibleFind(state, state.ourPlayerIndex, suitIndex, 2).length === 1 &&						// other copy isn't visible
+		!state.hands[state.ourPlayerIndex].some(c => c.matches(suitIndex, rank, { infer: true }));  // not in our hand
+}
+
+/**
+ * Returns the relative "value" of a card. 0 is worthless, 5 is critical.
+ * TODO: Improve general algorithm. (e.g. having clued cards of a suit makes it better, a dead suit is worse)
+ * @param  {State} state
+ * @param  {{ suitIndex: number, rank: number }} card
+ */
+export function card_value(state, card) {
+	const { suitIndex, rank } = card;
+
+	// Basic trash, saved already, duplicate visible
+	if (isTrash(state, state.ourPlayerIndex, suitIndex, rank) || visibleFind(state, state.ourPlayerIndex, suitIndex, rank).length > 1) {
+		return 0;
+	}
+
+	if (isCritical(state, suitIndex, rank)) {
+		return 5;
+	}
+
+	if (unique2(state, card)) {
+		return 4;
+	}
+
+	return rank - state.hypo_stacks[suitIndex];
+}
+
+/**
+ * Checks if the card is a valid (and safe) 2 save.
+ * @param {State} state
+ * @param {number} target 	The player with the card
+ * @param {{ suitIndex: number, rank: number }} card
+ */
+export function save2(state, target, card) {
+	if (card.rank !== 2) {
+		return false;
+	}
+
+	const clue = { type: CLUE.RANK, value: 2, target };
+	return unique2(state, card) && clue_safe(state, clue);
 }

--- a/src/conventions/h-group/clue-finder/clue-safe.js
+++ b/src/conventions/h-group/clue-finder/clue-safe.js
@@ -64,7 +64,8 @@ export function clue_safe(state, clue) {
 function unique2(state, card) {
 	const { suitIndex, rank } = card;
 
-	return state.play_stacks[suitIndex] === 0 &&													// play stack at 0
+	return rank === 2 &&
+		state.play_stacks[suitIndex] === 0 &&														// play stack at 0
 		visibleFind(state, state.ourPlayerIndex, suitIndex, 2).length === 1 &&						// other copy isn't visible
 		!state.hands[state.ourPlayerIndex].some(c => c.matches(suitIndex, rank, { infer: true }));  // not in our hand
 }
@@ -91,7 +92,8 @@ export function card_value(state, card) {
 		return 4;
 	}
 
-	return rank - state.hypo_stacks[suitIndex];
+	// Next playable rank is value 4, rank 4 with nothing on the stack is value 1
+	return 5 - (rank - state.hypo_stacks[suitIndex]);
 }
 
 /**

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -150,7 +150,7 @@ export function determine_clue(state, target, target_card, options) {
 			continue;
 		}
 
-		const { inferred: interpret } = hypo_state.hands[target].find(c => c.order === target_card.order);
+		const interpret = hypo_state.hands[target].find(c => c.order === target_card.order).inferred;
 		let elim = 0, new_touched = 0, bad_touch = 0, trash = 0;
 
 		// Count the number of cards that have increased elimination (i.e. cards that were "filled in")

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -142,7 +142,7 @@ export function determine_clue(state, target, target_card, options) {
 		const bad_touch_cards = find_bad_touch(state, touch.filter(c => !c.clued), focused_card.order);		// Ignore cards that were already clued
 
 		// Simulate clue from receiver's POV to see if they have the right interpretation
-		const action = { type: 'clue', giver: state.ourPlayerIndex, target, list, clue };
+		const action = Object.freeze({ type: 'clue', giver: state.ourPlayerIndex, target, list, clue });
 		const hypo_state = evaluate_clue(state, action, clue, target, target_card, bad_touch_cards);
 
 		// Clue had incorrect interpretation

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -133,9 +133,9 @@ export function determine_clue(state, target, target_card, options) {
 		const touch = hand.clueTouched(state.suits, clue);
 		const list = touch.map(c => c.order);
 
-		const { focused_card } = determine_focus(hand, list, { beforeClue: true });
+		const { focused_card, chop } = determine_focus(hand, list, { beforeClue: true });
 		if (focused_card.order !== target_card.order) {
-			logger.info(`${Utils.logClue(clue)} doesn't focus, ignoring`);
+			logger.info(`${Utils.logClue(clue)} focuses ${Utils.logCard(focused_card)} instead of ${Utils.logCard(target_card)}, ignoring`);
 			continue;
 		}
 
@@ -220,8 +220,9 @@ export function determine_clue(state, target, target_card, options) {
 			}
 		}
 
+		// We only need to check remainder if this clue focuses chop, because we are changing chop to something else
 		const new_chop = hypo_state.hands[target][find_chop(hypo_state.hands[target], { includeNew: true })];
-		const remainder = new_chop !== undefined ? card_value(state, new_chop) : 0;
+		const remainder = (chop && new_chop !== undefined) ? card_value(state, new_chop) : 0;
 
 		const result_log = {
 			clue: Utils.logClue(clue),

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -1,8 +1,9 @@
 import { CLUE } from '../../../constants.js';
-import { clue_safe } from './clue-safe.js';
-import { determine_focus, find_bad_touch } from '../hanabi-logic.js';
+import { card_value, clue_safe } from './clue-safe.js';
+import { determine_focus, find_chop, find_bad_touch } from '../hanabi-logic.js';
 import { cardTouched, isCluable } from '../../../variants.js';
 import { isTrash } from '../../../basics/hanabi-util.js';
+import { find_clue_value } from '../action-helper.js';
 import logger from '../../../logger.js';
 import * as Utils from '../../../util.js';
 
@@ -10,9 +11,10 @@ import * as Utils from '../../../util.js';
  * @typedef {import('../../h-group.js').default} State
  * @typedef {import('../../../basics/Card.js').Card} Card
  * @typedef {import('../../../types.js').Clue} Clue
+ * @typedef {import('../../../types.js').ClueAction} ClueAction
  * @typedef {import('../../../types.js').ClueResult} ClueResult
  *
- * @typedef {{ excludeColour: boolean, excludeRank: boolean }} ClueOptions
+ * @typedef {{ excludeColour: boolean, excludeRank: boolean, save: boolean }} ClueOptions
  */
 
 /**
@@ -49,6 +51,67 @@ export function direct_clues(state, target, card, options) {
 }
 
 /**
+ * Evaluates the result of a clue. Returns the hypothetical state after the clue if correct, otherwise undefined.
+ * @param  {State} state
+ * @param  {ClueAction} action
+ * @param  {Clue} clue
+ * @param  {number} target
+ * @param  {Card} target_card
+ * @param  {Card[]} bad_touch_cards
+ */
+export function evaluate_clue(state, action, clue, target, target_card, bad_touch_cards) {
+	// Prevent outputting logs until we know that the result is correct
+	logger.collect();
+
+	logger.info(`------- ENTERING HYPO ${Utils.logClue(clue)} --------`);
+
+	const hypo_state = state.simulate_clue(action, { enableLogs: true });
+
+	logger.info('------- EXITING HYPO --------');
+
+	const correct = hypo_state.hands[target].every((card, index) => {
+		// The focused card must not have been reset and must match inferences
+		if (card.order === target_card.order) {
+			return !card.reset && card.matches_inferences();
+		}
+
+		const old_card = state.hands[target][index];
+
+		// For non-focused cards:
+		return (!card.reset && card.matches_inferences()) || 		// Matches inferences
+			((old_card.reset || !old_card.matches_inferences()) ||	// Didn't match inference even before clue
+			bad_touch_cards.some(c => c.order === card.order) ||	// Bad touched
+			card.possible.every(c => isTrash(hypo_state, target, c.suitIndex, c.rank, card.order)));	// Known trash
+	});
+
+	// Print out logs if the result is correct
+	logger.flush(correct);
+
+	if (!correct) {
+		let reason = '';
+		for (const card of hypo_state.hands[target]) {
+			if (card.reset) {
+				reason = `card ${Utils.logCard(card)} lost all inferences and was reset`;
+				break;
+			}
+			if (!card.matches_inferences()) {
+				reason = `card ${Utils.logCard(card)} has inferences [${card.inferred.map(c => Utils.logCard(c)).join(',')}], doesn't match`;
+				break;
+			}
+			if (!card.possible.every(c => isTrash(hypo_state, target, c.suitIndex, c.rank, card.order))) {
+				const not_trash_possibility = Utils.logCard(card.possible.find(c => !isTrash(hypo_state, target, c.suitIndex, c.rank, card.order)));
+				reason = `card ${Utils.logCard(card)} has ${not_trash_possibility} possibility not trash`;
+				break;
+			}
+		}
+		logger.info(`${Utils.logClue(clue)} has incorrect interpretation, (${reason})`);
+		return undefined;
+	}
+
+	return hypo_state;
+}
+
+/**
  * Returns the best clue to focus the target card.
  * @param {State} state
  * @param {number} target 					The player index with the card.
@@ -60,7 +123,8 @@ export function determine_clue(state, target, target_card, options) {
 	logger.info('determining clue to target card', Utils.logCard(target_card));
 	const hand = state.hands[target];
 
-	const possible_clues = direct_clues(state, target, target_card, options).filter(clue => clue_safe(state, clue));
+	// All play clues should be safe, but save clues may not be (e.g. crit 4, 5 of different colour needs to identify that 5 is a valid clue)
+	const possible_clues = direct_clues(state, target, target_card, options).filter(clue => options.save ? true : clue_safe(state, clue));
 
 	/** @type {ClueResult[]} */
 	const results = [];
@@ -70,29 +134,24 @@ export function determine_clue(state, target, target_card, options) {
 		const list = touch.map(c => c.order);
 
 		const { focused_card } = determine_focus(hand, list, { beforeClue: true });
-		const bad_touch_cards = find_bad_touch(state, touch.filter(c => !c.clued), focused_card.order);		// Ignore cards that were already clued
-
 		if (focused_card.order !== target_card.order) {
 			logger.info(`${Utils.logClue(clue)} doesn't focus, ignoring`);
 			continue;
 		}
 
+		const bad_touch_cards = find_bad_touch(state, touch.filter(c => !c.clued), focused_card.order);		// Ignore cards that were already clued
+
 		// Simulate clue from receiver's POV to see if they have the right interpretation
 		const action = { type: 'clue', giver: state.ourPlayerIndex, target, list, clue };
+		const hypo_state = evaluate_clue(state, action, clue, target, target_card, bad_touch_cards);
 
-		// Prevent outputting logs until we know that the result is correct
-		logger.collect();
+		// Clue had incorrect interpretation
+		if (hypo_state === undefined) {
+			continue;
+		}
 
-		logger.info(`------- ENTERING HYPO ${Utils.logClue(clue)} --------`);
-
-		const hypo_state = state.simulate_clue(action, { enableLogs: true });
-
-		logger.info('------- EXITING HYPO --------');
-
-		const card_after_cluing = hypo_state.hands[target].find(c => c.order === target_card.order);
-		const { inferred: inferred_after_cluing } = card_after_cluing;
-		let elim = 0;
-		let new_touched = 0;
+		const { inferred: interpret } = hypo_state.hands[target].find(c => c.order === target_card.order);
+		let elim = 0, new_touched = 0, bad_touch = 0, trash = 0;
 
 		// Count the number of cards that have increased elimination (i.e. cards that were "filled in")
 		for (let i = 0; i < state.hands[target].length; i++) {
@@ -107,44 +166,6 @@ export function determine_clue(state, target, target_card, options) {
 			}
 		}
 
-		const interpret = inferred_after_cluing;
-		const correct = hypo_state.hands[target].every((card, index) => {
-			// The focused card must not have been reset and must match inferences
-			if (card.order === target_card.order) {
-				return !card.reset && card.matches_inferences();
-			}
-
-			const old_card = state.hands[target][index];
-
-			// For non-focused cards:
-			return (!card.reset && card.matches_inferences()) || 		// Matches inferences
-				((old_card.reset || !old_card.matches_inferences()) ||	// Didn't match inference even before clue
-				bad_touch_cards.some(c => c.order === card.order) ||	// Bad touched
-				card.possible.every(c => isTrash(hypo_state, target, c.suitIndex, c.rank, card.order)));	// Known trash
-		});
-
-		// Print out logs if the result is correct
-		logger.flush(correct);
-
-		if (!correct) {
-			logger.info(`${Utils.logClue(clue)} has incorrect interpretation, ignoring`);
-			/*logger.info(hypo_state.hands[target].map(card => {
-				if (card.reset || !card.matches_inferences()) {
-					logger.info(`card ${Utils.logCard(card)} has inferences [${card.inferred.map(c => Utils.logCard(c)).join(',')}] reset? ${card.reset}`);
-					logger.info(Utils.logHand(hypo_state.hands[target]));
-				}
-				if (!card.possible.every(c => isTrash(hypo_state, target, c.suitIndex, c.rank, card.order))) {
-					logger.info(`${Utils.logCard(card.possible.find(c => !isTrash(hypo_state, target, c.suitIndex, c.rank, card.order)))} possibility is not trash`);
-				}
-				return bad_touch_cards.some(c => c.order === card.order) ||							// Card is bad touched
-					card.possible.every(c => isTrash(hypo_state, target, c.suitIndex, c.rank, card.order)) || 	// Card is known trash
-					(!card.reset && card.matches_inferences());										// Card matches interpretation
-			}));*/
-			continue;
-		}
-
-		let bad_touch = 0;
-		let trash = 0;
 		for (const card of hypo_state.hands[target]) {
 			if (bad_touch_cards.some(c => c.order === card.order)) {
 				// Known trash
@@ -199,6 +220,9 @@ export function determine_clue(state, target, target_card, options) {
 			}
 		}
 
+		const new_chop = hypo_state.hands[target][find_chop(hypo_state.hands[target], { includeNew: true })];
+		const remainder = new_chop !== undefined ? card_value(state, new_chop) : 0;
+
 		const result_log = {
 			clue: Utils.logClue(clue),
 			bad_touch,
@@ -209,71 +233,21 @@ export function determine_clue(state, target, target_card, options) {
 			finesses,
 			playables: playables.map(({ playerIndex, card }) => {
 				return { player: state.playerNames[playerIndex], card: Utils.logCard(card) };
-			})
+			}),
+			remainder
 		};
 		logger.info('result,', result_log);
 
-		results.push({ clue, touch, interpret, elim, new_touched, bad_touch, trash, finesses, playables});
+		results.push({ clue, touch, interpret, elim, new_touched, bad_touch, trash, finesses, playables, remainder });
 	}
 
 	if (results.length === 0) {
 		return;
 	}
 
-	const fields = [
-		{ field: 'bad_touch', reverse: true },
-		{ field: 'finesses' },
-		{ field: 'playables', length: true },
-		{ field: 'new_touched' },
-		{ field: 'elim' },
-		{ field: 'interpret', reverse: true, length: true }
-	];
-
-	const best_result = filterMax(results, fields);
+	const best_result = Utils.maxOn(results, find_clue_value);
 	const { clue } = best_result;
 
 	// Change type from CLUE to ACTION
 	return { type: clue.type + 2, value: clue.value, target: clue.target, result: best_result };
-}
-
-/**
- * Given an array of objects, returns the element that has the highest value based on the given fields.
- * @template T
- * @param {T[]} array
- * @param {{field: string, reverse?: boolean, length?: boolean}[]} fields
- */
-function filterMax(array, fields) {
-	let field_index = 0;
-
-	while (array.length > 1 && field_index < fields.length) {
-		const { field, reverse, length } = fields[field_index];
-		let max = [array[0]];
-
-		for (let i = 1; i < array.length; i++) {
-			const item = array[i];
-			let arg1 = item[field], arg2 = max[0][field];
-
-			if (length) {
-				arg1 = arg1.length;
-				arg2 = arg2.length;
-			}
-
-			if (reverse) {
-				const arg3 = arg1;
-				arg1 = arg2;
-				arg2 = arg3;
-			}
-
-			if (arg1 > arg2) {
-				max = [item];
-			}
-			else if (arg1 === arg2) {
-				max.push(item);
-			}
-		}
-		array = max;
-		field_index++;
-	}
-
-	return array[0];
 }

--- a/src/conventions/h-group/clue-finder/fix-clues.js
+++ b/src/conventions/h-group/clue-finder/fix-clues.js
@@ -159,7 +159,7 @@ function check_fixed(state, target, card, clue, fix_criteria) {
 	const hand = state.hands[target];
 	const touch = hand.clueTouched(state.suits, clue);
 
-	const action = { type: 'clue', giver: state.ourPlayerIndex, target, list: touch.map(c => c.order), clue };
+	const action = Object.freeze({ type: 'clue', giver: state.ourPlayerIndex, target, list: touch.map(c => c.order), clue });
 
 	// Prevent outputting logs until we know that the result is correct
 	logger.collect();

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -128,6 +128,13 @@ export function find_connecting(state, giver, target, suitIndex, rank, ignoreOrd
 	logger.info(`couldn't find connecting ${Utils.logCard({suitIndex, rank})}`);
 }
 
+/**
+ * Returns whether the playerIndex is "in between" the giver and target (in play order).
+ * @param {number} numPlayers
+ * @param {number} playerIndex
+ * @param {number} giver
+ * @param {number} target
+ */
 function inBetween(numPlayers, playerIndex, giver, target) {
 	let i = (giver + 1) % numPlayers;
 	while(i !== target) {

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -3,7 +3,7 @@ import { LEVEL } from '../h-constants.js';
 import { Card } from '../../../basics/Card.js';
 import { interpret_tcm, interpret_5cm } from './interpret-cm.js';
 import { stalling_situation } from './interpret-stall.js';
-import { determine_focus, find_chop } from '../hanabi-logic.js';
+import { determine_focus } from '../hanabi-logic.js';
 import { find_focus_possible } from './focus-possible.js';
 import { find_own_finesses } from './connecting-cards.js';
 import { bad_touch_possiblities, update_hypo_stacks, good_touch_elim } from '../../../basics/helper.js';

--- a/src/conventions/h-group/h-constants.js
+++ b/src/conventions/h-group/h-constants.js
@@ -1,6 +1,6 @@
-export const LEVEL = {
+export const LEVEL = Object.freeze({
 	FIX: 3,
 	SARCASTIC: 3,
 	BASIC_CM: 4,
 	STALLING: 9
-};
+});

--- a/src/conventions/h-group/interpret-play.js
+++ b/src/conventions/h-group/interpret-play.js
@@ -56,7 +56,7 @@ export function interpret_play(state, action) {
         check_ocm(state, action);
     }
 
-    Basics.onPlay(this, /** @type {PlayAction} */ (action));
+    Basics.onPlay(this, action);
 
     // Apply good touch principle on remaining possibilities
     for (const hand of this.hands) {

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -12,11 +12,13 @@ import * as Utils from '../../util.js';
 /**
  * @typedef {import('../h-group.js').default} State
  * @typedef {import('../../basics/Hand.js').Hand} Hand
+ * @typedef {import('../../types.js').PerformAction} PerformAction
  */
 
 /**
  * Performs the most appropriate action given the current state.
  * @param {State} state
+ * @return {PerformAction}
  */
 export function take_action(state) {
 	const { tableID } = state;

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -85,7 +85,6 @@ export function take_action(state) {
 	// Playing into finesse/bluff
 	if (playable_cards.length > 0 && priority === 0) {
 		return { tableID, type: ACTION.PLAY, target: best_playable_card.order };
-		return;
 	}
 
 	// Get a high value play clue

--- a/src/types.js
+++ b/src/types.js
@@ -1,12 +1,15 @@
 // @ts-nocheck
 
 /**
- * @typedef Clue
- * @property {number} type
- * @property {number} target
- * @property {number} value
- * @property {ClueResult} [result]
+ * @typedef BasicCard
+ * @property {number} suitIndex
+ * @property {number} rank 
  * 
+ * @typedef BaseClue
+ * @property {number} type
+ * @property {number} value
+ * 
+ * @typedef {BaseClue & {target: number, result?: ClueResult}} Clue
  * @typedef {Clue & {urgent: boolean, trash: boolean}} FixClue
  * 
  * @typedef ClueResult
@@ -21,31 +24,44 @@
  * @property {number} remainder
  * @property {({playerIndex: number, card: Card})[]} playables
  * 
+ * @typedef StatusAction
+ * @property {'status'} type
+ * @property {number}   clues
+ * @property {number}   score
+ * @property {number}   maxScore
+ * 
+ * @typedef TurnAction
+ * @property {'turn'}   type
+ * @property {number}   num
+ * @property {number}   currentPlayerIndex
  * 
  * @typedef ClueAction
- * @property {string} 	type
+ * @property {'clue'}   type
  * @property {number} 	giver
  * @property {number} 	target
  * @property {number[]} list
- * @property {Omit<Clue, 'target'>} 	clue
+ * @property {BaseClue} clue
  * @property {boolean}  [mistake]
  * @property {boolean}  [ignoreStall]
  * 
  * @typedef CardAction
- * @property {string} type
  * @property {number} order
  * @property {number} playerIndex
  * @property {number} suitIndex
  * @property {number} rank
  * 
- * @typedef {CardAction & {failed: boolean}} DiscardAction
- * @typedef {Omit<CardAction, 'type'>} PlayAction
+ * @typedef {CardAction & {type: 'draw'}} DrawAction
+ * @typedef {CardAction & {type: 'play'}} PlayAction
+ * @typedef {CardAction & {type:'rewind'}} RewindAction
+ * @typedef {CardAction & {type: 'discard', failed: boolean}} DiscardAction
  * 
- * @typedef TurnAction
- * @property {string} type
- * @property {number} [currentPlayerIndex]
+ * @typedef GameOverAction
+ * @property {'gameOver'}   type
+ * @property {number}       endCondition
+ * @property {number}       playerIndex
+ * @property {any}          votes
  * 
- * @typedef {{type: string} & Partial<(ClueAction & DiscardAction & TurnAction)>} Action
+ * @typedef {StatusAction | TurnAction | ClueAction | DrawAction | DiscardAction | PlayAction | GameOverAction | RewindAction} Action
  * 
  * @typedef PerformAction
  * @property {number} tableID`

--- a/src/types.js
+++ b/src/types.js
@@ -18,6 +18,7 @@
  * @property {number} bad_touch
  * @property {number} trash
  * @property {number} finesses
+ * @property {number} remainder
  * @property {({playerIndex: number, card: Card})[]} playables
  * 
  * 

--- a/src/util.js
+++ b/src/util.js
@@ -140,6 +140,27 @@ export function objPick(obj, attributes) {
 }
 
 /**
+ * Returns the "maximum" object in an array based on a value function.
+ * @template T
+ * @param  {T[]} arr 					The array of objects.
+ * @param  {(obj: T) => number} valueFunc	A function that takes in an object and returns its value.
+ */
+export function maxOn(arr, valueFunc) {
+	let max_value = valueFunc(arr[0]), max = arr[0];
+
+	for (let i = 0; i < arr.length; i++) {
+		const curr = valueFunc(arr[i]);
+
+		if (curr > max_value) {
+			max_value = curr;
+			max = arr[i];
+		}
+	}
+
+	return max;
+}
+
+/**
  * Checks if two objects look the same (i.e. have the same properties).
  */
 export function objEquals(obj1, obj2) {

--- a/test/h-group/level-1-part2.js
+++ b/test/h-group/level-1-part2.js
@@ -3,12 +3,12 @@ import { strict as assert } from 'node:assert';
 // @ts-ignore
 import { describe, it } from 'node:test';
 
-import { COLOUR, PLAYER, setup } from '../test-utils.js';
+import { COLOUR, PLAYER, expandShortCard, getRawInferences, setup } from '../test-utils.js';
 import HGroup from '../../src/conventions/h-group.js';
 import { take_action } from '../../src/conventions/h-group/take-action.js';
 import * as Utils from '../../src/util.js';
 import logger from '../../src/logger.js';
-import { ACTION } from '../../src/constants.js';
+import { ACTION, CLUE } from '../../src/constants.js';
 
 logger.setLevel(logger.LEVELS.ERROR);
 
@@ -23,10 +23,10 @@ describe('save clue', () => {
 		state.play_stacks = [1, 5, 1, 0, 5];
 		state.clue_tokens = 2;
 
-		// Bob's last 3 cards are clued
+		// Bob's last 3 cards are clued.
 		[2,3,4].forEach(index => state.hands[PLAYER.BOB][index].clued = true);
 
-		// Cathy's last 2 cards are clued
+		// Cathy's last 2 cards are clued.
 		[3,4].forEach(index => state.hands[PLAYER.CATHY][index].clued = true);
 
 		const action = take_action(state);
@@ -35,4 +35,52 @@ describe('save clue', () => {
 		assert.deepEqual(Utils.objPick(action, ['type', 'target', 'value']), { type: ACTION.COLOUR, target: PLAYER.CATHY, value: COLOUR.GREEN });
 	});
 
+	it('prefers touching less cards to save critical cards', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'g5', 'p2', 'p4', 'g4']
+		]);
+
+		// g4 is discarded.
+		state.discard_stacks[COLOUR.GREEN] = [0, 0, 0, 1, 0];
+
+		// Bob's p2 is clued.
+		state.hands[PLAYER.BOB][2].clued = true;
+
+		const action = take_action(state);
+
+		// Alice should give green to Bob instead of 4
+		assert.deepEqual(Utils.objPick(action, ['type', 'target', 'value']), { type: ACTION.COLOUR, target: PLAYER.BOB, value: COLOUR.GREEN });
+	});
+
+	/*it('understands that a save clue cannot be a finesse', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b2', 'y4', 'p4', 'b5', 'p3'],
+			['g1', 'b4', 'r5', 'y4', 'g4']
+		]);
+
+		// Blue stack is at 1.
+		state.play_stacks[COLOUR.BLUE] = 1;
+
+		// b3 is both discarded.
+		state.discard_stacks[COLOUR.BLUE] = [0, 0, 0, 0, 0];
+
+		// Cathy clues Alice's slot 5 with blue.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.BLUE }, giver: PLAYER.CATHY, list: [0], target: PLAYER.ALICE });
+
+		console.log(JSON.stringify(getRawInferences(state.hands[PLAYER.ALICE][4])));
+		// assert.deepEqual(getRawInferences(state.hands[PLAYER.ALICE][4]), ['b2', 'b3'].map(expandShortCard));
+		// assert.equal(state.hands[PLAYER.BOB][0].finessed, false);
+		assert.equal(state.waiting_connections.length, 0);
+
+		// We discard slot 4.
+		state.handle_action({ type: 'discard', order: 1, playerIndex: PLAYER.ALICE, suitIndex: COLOUR.BLUE, rank: 4, failed: false });
+
+		// Bob discards slot 5.
+		state.handle_action({ type: 'discard', order: 5, playerIndex: PLAYER.BOB, suitIndex: COLOUR.PURPLE, rank: 3, failed: false });
+
+		console.log(JSON.stringify(getRawInferences(state.hands[PLAYER.ALICE][3])));
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.ALICE][3]), ['b2', 'b3'].map(expandShortCard));
+	});*/
 });

--- a/test/h-group/level-1-part2.js
+++ b/test/h-group/level-1-part2.js
@@ -1,0 +1,38 @@
+// @ts-ignore
+import { strict as assert } from 'node:assert';
+// @ts-ignore
+import { describe, it } from 'node:test';
+
+import { COLOUR, PLAYER, setup } from '../test-utils.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { take_action } from '../../src/conventions/h-group/take-action.js';
+import * as Utils from '../../src/util.js';
+import logger from '../../src/logger.js';
+import { ACTION } from '../../src/constants.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+describe('save clue', () => {
+	it('prefers play over save with >1 clues', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+			['g3', 'p1', 'b3', 'b2', 'b5']
+		]);
+
+		state.play_stacks = [1, 5, 1, 0, 5];
+		state.clue_tokens = 2;
+
+		// Bob's last 3 cards are clued
+		[2,3,4].forEach(index => state.hands[PLAYER.BOB][index].clued = true);
+
+		// Cathy's last 2 cards are clued
+		[3,4].forEach(index => state.hands[PLAYER.CATHY][index].clued = true);
+
+		const action = take_action(state);
+
+		// Alice should give green to Cathy to finesse over save
+		assert.deepEqual(Utils.objPick(action, ['type', 'target', 'value']), { type: ACTION.COLOUR, target: PLAYER.CATHY, value: COLOUR.GREEN });
+	});
+
+});

--- a/test/h-group/level-1.js
+++ b/test/h-group/level-1.js
@@ -20,8 +20,7 @@ describe('play clue', () => {
 		]);
 
 		// Alice clues Bob red on slot 2.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8], target: PLAYER.BOB, turn: 0 });;
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8], target: PLAYER.BOB });
 
 		// Target card should be inferred as r1.
 		const targetCard = state.hands[PLAYER.BOB][1];
@@ -35,8 +34,7 @@ describe('play clue', () => {
 		]);
 
 		// Alice clues Bob red on slots 1, 2 and 3.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7, 8, 9], target: PLAYER.BOB, turn: 0 });;
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7, 8, 9], target: PLAYER.BOB });
 
 		// Bob's slot 1 should be inferred as r1.
 		const targetCard = state.hands[PLAYER.BOB][0];
@@ -50,8 +48,7 @@ describe('play clue', () => {
 		]);
 
 		// Alice clues Bob red on slots 1, 2 and 3.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [5, 8, 9], target: PLAYER.BOB, turn: 0 });;
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [5, 8, 9], target: PLAYER.BOB });
 
 		// Bob's slot 5 (chop) should be inferred as r1.
 		const targetCard = state.hands[PLAYER.BOB][4];
@@ -67,8 +64,7 @@ describe('play clue', () => {
 		state.play_stacks[COLOUR.RED] = 2;
 
 		// Alice clues Bob red on slot 3.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 });;
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB });
 
 		// Bob's slot 3 should be inferred as r3.
 		const targetCard = state.hands[PLAYER.BOB][2];
@@ -88,8 +84,7 @@ describe('play clue', () => {
 		state.hands[PLAYER.CATHY][1].intersect('inferred', ['r1'].map(expandShortCard));
 
 		// Alice clues Bob red on slot 3.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 });;
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB });
 
 		// Bob's slot 3 should be inferred as r2.
 		const targetCard = state.hands[PLAYER.BOB][2];
@@ -108,8 +103,7 @@ describe('play clue', () => {
 		state.hands[PLAYER.BOB][1].intersect('inferred', ['r1', 'y1', 'g1', 'b1', 'p1'].map(expandShortCard));
 
 		// Alice clues Bob red in slots 1 and 2 (filling in red 1).
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8, 9], target: PLAYER.BOB, turn: 0 });;
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8, 9], target: PLAYER.BOB });
 
 		// Bob's slot 1 should be inferred as r2.
 		const targetCard = state.hands[PLAYER.BOB][0];

--- a/test/h-group/level-1.js
+++ b/test/h-group/level-1.js
@@ -20,7 +20,7 @@ describe('play clue', () => {
 		]);
 
 		// Alice clues Bob red on slot 2.
-		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8], target: PLAYER.BOB, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8], target: PLAYER.BOB, turn: 0 });;
 		state.handle_action(action);
 
 		// Target card should be inferred as r1.
@@ -35,7 +35,7 @@ describe('play clue', () => {
 		]);
 
 		// Alice clues Bob red on slots 1, 2 and 3.
-		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7, 8, 9], target: PLAYER.BOB, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7, 8, 9], target: PLAYER.BOB, turn: 0 });;
 		state.handle_action(action);
 
 		// Bob's slot 1 should be inferred as r1.
@@ -50,7 +50,7 @@ describe('play clue', () => {
 		]);
 
 		// Alice clues Bob red on slots 1, 2 and 3.
-		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [5, 8, 9], target: PLAYER.BOB, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [5, 8, 9], target: PLAYER.BOB, turn: 0 });;
 		state.handle_action(action);
 
 		// Bob's slot 5 (chop) should be inferred as r1.
@@ -67,7 +67,7 @@ describe('play clue', () => {
 		state.play_stacks[COLOUR.RED] = 2;
 
 		// Alice clues Bob red on slot 3.
-		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 });;
 		state.handle_action(action);
 
 		// Bob's slot 3 should be inferred as r3.
@@ -88,7 +88,7 @@ describe('play clue', () => {
 		state.hands[PLAYER.CATHY][1].intersect('inferred', ['r1'].map(expandShortCard));
 
 		// Alice clues Bob red on slot 3.
-		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [7], target: PLAYER.BOB, turn: 0 });;
 		state.handle_action(action);
 
 		// Bob's slot 3 should be inferred as r2.
@@ -108,7 +108,7 @@ describe('play clue', () => {
 		state.hands[PLAYER.BOB][1].intersect('inferred', ['r1', 'y1', 'g1', 'b1', 'p1'].map(expandShortCard));
 
 		// Alice clues Bob red in slots 1 and 2 (filling in red 1).
-		const action = { type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8, 9], target: PLAYER.BOB, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.ALICE, list: [8, 9], target: PLAYER.BOB, turn: 0 });;
 		state.handle_action(action);
 
 		// Bob's slot 1 should be inferred as r2.

--- a/test/h-group/level-3.js
+++ b/test/h-group/level-3.js
@@ -21,8 +21,7 @@ describe('playing 1s in the correct order', () => {
 		], 3);
 
 		// Bob clues Alice 1, touching slots 3 and 4.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 2], target: PLAYER.ALICE, turn: 0 });
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 2], target: PLAYER.ALICE });
 
 		const ordered_1s = order_1s(state, state.hands[PLAYER.ALICE]).map(c => c.order);
 		assert.deepEqual(Array.from(ordered_1s), [1, 2]);
@@ -38,8 +37,7 @@ describe('playing 1s in the correct order', () => {
 		state.hands[PLAYER.ALICE][0].order = 10;
 
 		// Bob clues Alice 1, touching slots 1 and 4.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 10], target: PLAYER.ALICE, turn: 0 });
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 10], target: PLAYER.ALICE });
 
         const ordered_1s = order_1s(state, state.hands[PLAYER.ALICE]).map(c => c.order);
 		assert.deepEqual(Array.from(ordered_1s), [10, 1]);
@@ -55,8 +53,7 @@ describe('playing 1s in the correct order', () => {
         state.hands[PLAYER.ALICE][0].order = 10;
 
 		// Bob clues Alice 1, touching slots 1, 2 and 5.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [0, 3, 10], target: PLAYER.ALICE, turn: 0 });
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [0, 3, 10], target: PLAYER.ALICE });
 
 		const ordered_1s = order_1s(state, state.hands[PLAYER.ALICE]).map(c => c.order);
 		assert.deepEqual(Array.from(ordered_1s), [0, 10, 3]);

--- a/test/h-group/level-3.js
+++ b/test/h-group/level-3.js
@@ -21,7 +21,7 @@ describe('playing 1s in the correct order', () => {
 		], 3);
 
 		// Bob clues Alice 1, touching slots 3 and 4.
-		const action = { type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 2], target: PLAYER.ALICE, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 2], target: PLAYER.ALICE, turn: 0 });
 		state.handle_action(action);
 
 		const ordered_1s = order_1s(state, state.hands[PLAYER.ALICE]).map(c => c.order);
@@ -38,7 +38,7 @@ describe('playing 1s in the correct order', () => {
 		state.hands[PLAYER.ALICE][0].order = 10;
 
 		// Bob clues Alice 1, touching slots 1 and 4.
-		const action = { type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 10], target: PLAYER.ALICE, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [1, 10], target: PLAYER.ALICE, turn: 0 });
 		state.handle_action(action);
 
         const ordered_1s = order_1s(state, state.hands[PLAYER.ALICE]).map(c => c.order);
@@ -55,7 +55,7 @@ describe('playing 1s in the correct order', () => {
         state.hands[PLAYER.ALICE][0].order = 10;
 
 		// Bob clues Alice 1, touching slots 1, 2 and 5.
-		const action = { type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [0, 3, 10], target: PLAYER.ALICE, turn: 0 };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [0, 3, 10], target: PLAYER.ALICE, turn: 0 });
 		state.handle_action(action);
 
 		const ordered_1s = order_1s(state, state.hands[PLAYER.ALICE]).map(c => c.order);

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -118,8 +118,7 @@ describe('giving order chop move', () => {
 		], 4);
 
 		// Bob clues Alice 1, touching slots 3 and 4.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE });
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE });
 
 		const our_hand = state.hands[state.ourPlayerIndex];
 
@@ -139,8 +138,7 @@ describe('giving order chop move', () => {
 		], 4);
 
 		// Bob clues Alice 1, touching slots 2, 3 and 4.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2, 3], target: PLAYER.ALICE });
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2, 3], target: PLAYER.ALICE });
 
 		const our_hand = state.hands[PLAYER.ALICE];
 
@@ -159,8 +157,7 @@ describe('giving order chop move', () => {
 		], 4);
 
 		// Bob clues Alice 1, touching slots 3 and 4.
-		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE });
-		state.handle_action(action);
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE });
 
 		const { save_clues } = find_clues(state);
 		assert.deepEqual(Utils.objPick(save_clues[PLAYER.BOB], ['type', 'value']), { type: ACTION.RANK, value: 5 });

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -118,7 +118,7 @@ describe('giving order chop move', () => {
 		], 4);
 
 		// Bob clues Alice 1, touching slots 3 and 4.
-		const action = { type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE });
 		state.handle_action(action);
 
 		const our_hand = state.hands[state.ourPlayerIndex];
@@ -139,7 +139,7 @@ describe('giving order chop move', () => {
 		], 4);
 
 		// Bob clues Alice 1, touching slots 2, 3 and 4.
-		const action = { type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2, 3], target: PLAYER.ALICE };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2, 3], target: PLAYER.ALICE });
 		state.handle_action(action);
 
 		const our_hand = state.hands[PLAYER.ALICE];
@@ -159,7 +159,7 @@ describe('giving order chop move', () => {
 		], 4);
 
 		// Bob clues Alice 1, touching slots 3 and 4.
-		const action = { type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE };
+		const action = Object.freeze({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [1, 2], target: PLAYER.ALICE });
 		state.handle_action(action);
 
 		const { save_clues } = find_clues(state);

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -40,10 +40,9 @@ export function setup(StateClass, hands, level) {
 		const hand = hands[playerIndex];
 		for (const short of hand.reverse()) {
 			const { suitIndex, rank } = expandShortCard(short);
-			const action = Object.freeze({ type: 'draw', order: orderCounter, playerIndex, suitIndex, rank });
 			orderCounter++;
 
-			state.handle_action(action);
+			state.handle_action({ type: 'draw', order: orderCounter, playerIndex, suitIndex, rank });
 		}
 	}
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -40,9 +40,9 @@ export function setup(StateClass, hands, level) {
 		const hand = hands[playerIndex];
 		for (const short of hand.reverse()) {
 			const { suitIndex, rank } = expandShortCard(short);
-			orderCounter++;
 
 			state.handle_action({ type: 'draw', order: orderCounter, playerIndex, suitIndex, rank });
+			orderCounter++;
 		}
 	}
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -40,7 +40,7 @@ export function setup(StateClass, hands, level) {
 		const hand = hands[playerIndex];
 		for (const short of hand.reverse()) {
 			const { suitIndex, rank } = expandShortCard(short);
-			const action = { type: 'draw', order: orderCounter, playerIndex, suitIndex, rank };
+			const action = Object.freeze({ type: 'draw', order: orderCounter, playerIndex, suitIndex, rank });
 			orderCounter++;
 
 			state.handle_action(action);


### PR DESCRIPTION
- Chop-focused clues now consider the new card on chop when evaluating its value.
  - This should reduce the number of clues that greedily touch a lot of not-yet useful cards.
- Types (particularly around the difference between PerformAction and other Actions) have been more clearly defined.