### PR TITLE
Support symmetric connections

### DIFF
--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -74,9 +74,9 @@ export function handle_action(action, catchup = false) {
 			const { currentPlayerIndex, num } = action;
 			this.turn_count = num + 1;
 
-			// Update notes on cards
-			for (const hand of this.hands) {
-				for (const card of hand) {
+			if (!catchup) {
+				// Update notes on cards
+				for (const card of this.hands.flat()) {
 					if (card.clued || card.finessed || card.chop_moved) {
 						const note = card.getNote();
 
@@ -95,7 +95,7 @@ export function handle_action(action, catchup = false) {
 							this.notes[card.order].full += `t${this.turn_count}: ${note}`;
 
 							if (this.in_progress) {
-								setTimeout(() => Utils.sendCmd('note', { tableID: this.tableID, order: card.order, note: this.notes[card.order].full }), Math.random() * 1000);
+								Utils.sendCmd('note', { tableID: this.tableID, order: card.order, note: this.notes[card.order].full });
 							}
 						}
 					}

--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -51,7 +51,6 @@ export function handle_action(action, catchup = false) {
 
 			// Assign the card's identity if it isn't already known
 			Object.assign(card, {suitIndex, rank});
-			card.intersect('possible', [{ suitIndex, rank }]);
 
 			logger.highlight('yellowb', `Turn ${this.turn_count}: ${logAction(action)}`);
 
@@ -123,7 +122,6 @@ export function handle_action(action, catchup = false) {
 
 			// Assign the card's identity if it isn't already known
 			Object.assign(card, {suitIndex, rank});
-			card.intersect('possible', [{ suitIndex, rank }]);
 
 			logger.highlight('yellowb', `Turn ${this.turn_count}: ${logAction(action)}`);
 

--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -20,6 +20,10 @@ import * as Utils from './tools/util.js';
 export function handle_action(action, catchup = false) {
 	this.actionList.push(action);
 
+	if (['clue', 'discard', 'play'].includes(action.type)) {
+		this.handHistory[this.turn_count] = Utils.objClone(this.hands[this.ourPlayerIndex]);
+	}
+
 	switch(action.type) {
 		case 'clue': {
 			// {type: 'clue', clue: { type: 1, value: 1 }, giver: 0, list: [ 8, 9 ], target: 1, turn: 0}
@@ -72,26 +76,28 @@ export function handle_action(action, catchup = false) {
 			this.turn_count = num + 1;
 
 			// Update notes on cards
-			for (const card of this.hands[this.ourPlayerIndex]) {
-				if (card.clued || card.finessed || card.chop_moved) {
-					const note = card.getNote();
+			for (const hand of this.hands) {
+				for (const card of hand) {
+					if (card.clued || card.finessed || card.chop_moved) {
+						const note = card.getNote();
 
-					if (this.notes[card.order] === undefined) {
-						this.notes[card.order] = { last: '', turn: 0, full: '' };
-					}
-
-					// Only write a new note if it's different from the last note and is a later turn
-					if (note !== this.notes[card.order].last && this.turn_count > this.notes[card.order].turn) {
-						this.notes[card.order].last = note;
-						this.notes[card.order].turn = this.turn_count;
-
-						if (this.notes[card.order].full !== '') {
-							this.notes[card.order].full += ' | ';
+						if (this.notes[card.order] === undefined) {
+							this.notes[card.order] = { last: '', turn: 0, full: '' };
 						}
-						this.notes[card.order].full += `t${this.turn_count}: ${note}`;
 
-						if (this.in_progress) {
-							setTimeout(() => Utils.sendCmd('note', { tableID: this.tableID, order: card.order, note: this.notes[card.order].full }), Math.random() * 1000);
+						// Only write a new note if it's different from the last note and is a later turn
+						if (note !== this.notes[card.order].last && this.turn_count > this.notes[card.order].turn) {
+							this.notes[card.order].last = note;
+							this.notes[card.order].turn = this.turn_count;
+
+							if (this.notes[card.order].full !== '') {
+								this.notes[card.order].full += ' | ';
+							}
+							this.notes[card.order].full += `t${this.turn_count}: ${note}`;
+
+							if (this.in_progress) {
+								setTimeout(() => Utils.sendCmd('note', { tableID: this.tableID, order: card.order, note: this.notes[card.order].full }), Math.random() * 1000);
+							}
 						}
 					}
 				}

--- a/src/basics.js
+++ b/src/basics.js
@@ -172,6 +172,12 @@ export function card_elim(state, playerIndex, suitIndex, rank) {
 				// Card can be further eliminated
 				if (card.inferred.length === 1 || card.possible.length === 1) {
 					const { suitIndex: suitIndex2, rank: rank2 } = card.identity({ symmetric: true, infer: true });
+
+					// Do not further eliminate on a rewinded card proven to be a different identity
+					if (playerIndex === state.ourPlayerIndex && card.possible.length > 1 && !card.matches(suitIndex2, rank2)) {
+						continue;
+					}
+
 					new_elims.push({ suitIndex: suitIndex2, rank: rank2 });
 
 					for (let i = 0; i < state.numPlayers; i++) {
@@ -189,7 +195,8 @@ export function card_elim(state, playerIndex, suitIndex, rank) {
 			return [];
 		}
 
-		let inferred_cards = visibleFind(state, playerIndex, suitIndex, rank);
+		let inferred_cards = visibleFind(state, playerIndex, suitIndex, rank).filter(c =>
+			!state.hands[state.ourPlayerIndex].some(card => card.order === c.order && card.rewinded && !card.matches(suitIndex, rank)));
 		let focus_elim = false;
 
 		if (base_count + inferred_cards.length >= total_count) {

--- a/src/basics/Hand.js
+++ b/src/basics/Hand.js
@@ -198,7 +198,7 @@ export class Hand extends Array {
 
 			// Find all unknown cards with the same inferences
 			const linked_cards = Array.from(this.filter(c =>
-				card.identity() === undefined &&
+				c.identity() === undefined &&
 				card.inferred.length === c.inferred.length &&
 				c.inferred.every(({suitIndex, rank}) => card.inferred.some(inf2 => inf2.matches(suitIndex, rank)))
 			));

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -231,9 +231,7 @@ export class State {
 
 		/** @param {Action} action */
 		const catchup_action = (action) => {
-			const our_action =
-				(action.type === 'clue' && action.giver === this.ourPlayerIndex) ||
-				((action.type === 'play' || action.type === 'discard') && action.playerIndex === this.ourPlayerIndex);
+			const our_action = action.type === 'clue' && action.giver === this.ourPlayerIndex;
 
 			const hypo_state = new_state.minimalCopy();
 

--- a/src/conventions/h-group.js
+++ b/src/conventions/h-group.js
@@ -15,6 +15,9 @@ export default class HGroup extends State {
 	update_turn = update_turn;
 	interpret_play = interpret_play;
 
+	hand_history = /** @type {HGroup_Hand[]} */ ([]);
+	hands = /** @type {HGroup_Hand[]} */ ([]);
+
 	/**
      * @param {number} tableID
      * @param {string[]} playerNames
@@ -25,7 +28,6 @@ export default class HGroup extends State {
 	constructor(tableID, playerNames, ourPlayerIndex, suits, in_progress, level = 1) {
 		super(tableID, playerNames, ourPlayerIndex, suits, in_progress);
 
-		/** @type HGroup_Hand[] */
 		this.hands = [];
 		for (let i = 0; i < playerNames.length; i++) {
 			this.hands.push(new HGroup_Hand(this, i));
@@ -49,7 +51,7 @@ export default class HGroup extends State {
 		}
 
 		const minimalProps = ['play_stacks', 'hypo_stacks', 'discard_stacks', 'max_ranks', 'hands',
-			'turn_count', 'clue_tokens', 'strikes', 'early_game', 'rewindDepth', 'next_ignore', 'cardsLeft'];
+			'turn_count', 'clue_tokens', 'strikes', 'early_game', 'rewindDepth', 'next_ignore', 'next_finesse', 'cardsLeft'];
 
 		for (const property of minimalProps) {
 			newState[property] = Utils.objClone(this[property]);

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -299,8 +299,11 @@ export function find_urgent_actions(state, play_clues, save_clues, fix_clues, pl
 				}
 			}
 
-			const bad_save = hand_after_save.isLocked() ?
-				hand.chopValue() < cardValue(state, hand_after_save.locked_discard()) :
+			const list = state.hands[target].clueTouched(save).map(c => c.order);
+			const hypo_state = state.simulate_clue({ type: 'clue', giver: state.ourPlayerIndex, list, clue: save, target });
+
+			const bad_save = hypo_state.hands[target].isLocked() ?
+				hand.chopValue() < cardValue(state, hypo_state.hands[target].locked_discard()) :
 				hand.chopValue() < hand_after_save.chopValue();
 
 			// Do not save at 1 clue if new chop or sacrifice discard are better than old chop

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -40,11 +40,6 @@ function find_known_connecting(state, giver, suitIndex, rank, ignoreOrders = [])
 				logger.info(`found known ${logCard({suitIndex, rank})} in ${state.playerNames[playerIndex]}'s hand`);
 				return { type: 'known', reacting: playerIndex, card, identity: { suitIndex, rank } };
 			}
-
-			if (card.rewinded && card.matches(suitIndex, rank)) {
-				logger.info(`found rewinded ${logCard({suitIndex, rank})} in own hand`);
-				return { type: 'known', reacting: playerIndex, card, identity: { suitIndex, rank } };
-			}
 		}
 	}
 
@@ -350,7 +345,7 @@ export function find_own_finesses(state, giver, target, suitIndex, rank, looksDi
 					return { feasible: false, connections: [] };
 				}
 
-				if (prompt?.rewinded && playableAway(hypo_state, prompt.suitIndex, prompt.rank) === 0) {
+				if (prompt?.rewinded && suitIndex !== prompt.suitIndex && playableAway(hypo_state, prompt.suitIndex, prompt.rank) === 0) {
 					if (state.level < LEVEL.INTERMEDIATE_FINESSES) {
 						logger.warn(`blocked hidden finesse at level ${state.level}`);
 						return { feasible: false, connections: [] };
@@ -445,7 +440,7 @@ function find_self_finesse(state, identity, ignoreOrders, finesses) {
 	let finesse = our_hand.find_finesse(ignoreOrders);
 	logger.debug('finesse in slot', finesse ? our_hand.findIndex(c => c.order === finesse.order) + 1 : '-1');
 
-	if (finesse?.rewinded && playableAway(state, finesse.suitIndex, finesse.rank) === 0) {
+	if (finesse?.rewinded && finesse.suitIndex !== suitIndex && playableAway(state, finesse.suitIndex, finesse.rank) === 0) {
 		if (state.level < LEVEL.INTERMEDIATE_FINESSES) {
 			logger.warn(`blocked layered finesse at level ${state.level}`);
 			return { feasible: false, connections: [] };

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -14,6 +14,7 @@ import { logCard } from '../../../tools/log.js';
  * @typedef {import('../../../basics/Card.js').Card} Card
  * @typedef {import('../../../types.js').Clue} Clue
  * @typedef {import('../../../types.js').Connection} Connection
+ * @typedef {import('../../../types.js').BasicCard} BasicCard
  */
 
 /**
@@ -37,12 +38,12 @@ function find_known_connecting(state, giver, suitIndex, rank, ignoreOrders = [])
 
 			if (card.matches(suitIndex, rank, { symmetric: true, infer: true }) && (card.identity() === undefined || card.matches(suitIndex, rank))) {
 				logger.info(`found known ${logCard({suitIndex, rank})} in ${state.playerNames[playerIndex]}'s hand`);
-				return { type: 'known', reacting: playerIndex, card };
+				return { type: 'known', reacting: playerIndex, card, identity: { suitIndex, rank } };
 			}
 
 			if (card.rewinded && card.matches(suitIndex, rank)) {
 				logger.info(`found rewinded ${logCard({suitIndex, rank})} in own hand`);
-				return { type: 'known', reacting: playerIndex, card };
+				return { type: 'known', reacting: playerIndex, card, identity: { suitIndex, rank } };
 			}
 		}
 	}
@@ -64,7 +65,7 @@ function find_known_connecting(state, giver, suitIndex, rank, ignoreOrders = [])
 		if (playables.length > 1 && state.hands[giver].some(c => c.clued && c.inferred.some(inf => inf.matches(suitIndex, rank)))) {
 			if (match !== undefined) {
 				// Everyone other than giver will recognize this card as the connection - stop looking further
-				return { type: 'terminate', reacting: null, card: null };
+				return { type: 'terminate', reacting: null, card: null, identity: null };
 			}
 			logger.info(`disallowed hidden delayed play on ${logCard({ suitIndex, rank })}, could be duplicated in giver's hand`);
 			return;
@@ -75,7 +76,7 @@ function find_known_connecting(state, giver, suitIndex, rank, ignoreOrders = [])
 				logger.warn(`hidden connecting card ${logCard({suitIndex, rank})} in ${state.playerNames[playerIndex]}'s hand, might be confusing`);
 			}
 			logger.info(`found playable ${logCard({suitIndex, rank})} in ${state.playerNames[playerIndex]}'s hand, with inferences ${match.inferred.map(c => logCard(c)).join()}`);
-			return { type: 'playable', reacting: playerIndex, card: match, known: playables.length === 1 };
+			return { type: 'playable', reacting: playerIndex, card: match, known: playables.length === 1, identity: { suitIndex, rank } };
 		}
 	}
 }
@@ -100,7 +101,7 @@ function find_unknown_connecting(state, giver, target, playerIndex, suitIndex, r
 	if (prompt !== undefined) {
 		if (prompt.matches(suitIndex, rank)) {
 			logger.info(`found prompt ${logCard(prompt)} in ${state.playerNames[playerIndex]}'s hand`);
-			return { type: 'prompt', reacting: playerIndex, card: prompt };
+			return { type: 'prompt', reacting: playerIndex, card: prompt, identity: { suitIndex, rank } };
 		}
 
 		// Prompted card is delayed playable
@@ -111,7 +112,7 @@ function find_unknown_connecting(state, giver, target, playerIndex, suitIndex, r
 				return;
 			}
 			logger.info(`found playable prompt ${logCard(prompt)} in ${state.playerNames[playerIndex]}'s hand`);
-			return { type: 'prompt', reacting: playerIndex, card: prompt, hidden: true };
+			return { type: 'prompt', reacting: playerIndex, card: prompt, hidden: true, identity: { suitIndex, rank } };
 		}
 		else {
 			logger.info(`wrong prompt on ${logCard(prompt)}`);
@@ -126,7 +127,7 @@ function find_unknown_connecting(state, giver, target, playerIndex, suitIndex, r
 				return;
 			}
 			logger.info(`found finesse ${logCard(finesse)} in ${state.playerNames[playerIndex]}'s hand`);
-			return { type: 'finesse', reacting: playerIndex, card: finesse };
+			return { type: 'finesse', reacting: playerIndex, card: finesse, identity: { suitIndex, rank } };
 		}
 		// Finessed card is delayed playable
 		else if (state.level >= LEVEL.INTERMEDIATE_FINESSES && state.play_stacks[finesse.suitIndex] + 1 === finesse.rank) {
@@ -136,7 +137,7 @@ function find_unknown_connecting(state, giver, target, playerIndex, suitIndex, r
 				return;
 			}
 			logger.info(`found playable finesse ${logCard(finesse)} in ${state.playerNames[playerIndex]}'s hand`);
-			return { type: 'finesse', reacting: playerIndex, card: finesse, hidden: true };
+			return { type: 'finesse', reacting: playerIndex, card: finesse, hidden: true, identity: { suitIndex, rank } };
 		}
 	}
 }
@@ -150,9 +151,10 @@ function find_unknown_connecting(state, giver, target, playerIndex, suitIndex, r
  * @param {number} rank
  * @param {boolean} looksDirect 	Whether the clue could be interpreted as direct play (i.e. never as self-prompt/finesse).
  * @param {number[]} [ignoreOrders] The orders of cards to ignore when searching.
+ * @param {{knownOnly?: number[]}} options
  * @returns {Connection[]}
  */
-export function find_connecting(state, giver, target, suitIndex, rank, looksDirect, ignoreOrders = []) {
+export function find_connecting(state, giver, target, suitIndex, rank, looksDirect, ignoreOrders = [], options = {}) {
 	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits[suitIndex], rank)) {
 		logger.info(`all ${logCard({suitIndex, rank})} in trash`);
 		return [];
@@ -178,6 +180,9 @@ export function find_connecting(state, giver, target, suitIndex, rank, looksDire
 	for (let i = 1; i < state.numPlayers; i++) {
 		const playerIndex = (giver + i) % state.numPlayers;
 
+		if (options.knownOnly?.includes(playerIndex)) {
+			continue;
+		}
 		if (playerIndex === target && looksDirect) {
 			// Clue receiver will not find known prompts/finesses in their hand unless no identities are delayed playable
 			continue;
@@ -227,12 +232,12 @@ export function find_connecting(state, giver, target, suitIndex, rank, looksDire
 				const ordered_1s = order_1s(state, playable_conns);
 
 				logger.info(`found playable ${logCard({suitIndex, rank})} in our hand, reordering to oldest 1`);
-				return [{ type: 'playable', reacting: state.ourPlayerIndex, card: ordered_1s[0], known: playable_conns.length === 1 }];
+				return [{ type: 'playable', reacting: state.ourPlayerIndex, card: ordered_1s[0], known: playable_conns.length === 1, identity: { suitIndex, rank } }];
 			}
 			else {
 				const playable_conn = playable_conns[0];
 				logger.info(`found playable ${logCard({suitIndex, rank})} in our hand, with inferences ${playable_conn.inferred.map(c => logCard(c)).join()}`);
-				return [{ type: 'playable', reacting: state.ourPlayerIndex, card: playable_conn, known: playable_conns.length === 1 }];
+				return [{ type: 'playable', reacting: state.ourPlayerIndex, card: playable_conn, known: playable_conns.length === 1, identity: { suitIndex, rank } }];
 			}
 		}
 	}
@@ -267,11 +272,13 @@ function inBetween(numPlayers, playerIndex, giver, target) {
  * @param {number} suitIndex
  * @param {number} rank
  * @param {boolean} looksDirect
+ * @param {number} [ignorePlayer]
+ * @param {number[]} [selfRanks]
  * @returns {{feasible: boolean, connections: Connection[]}}
  */
-export function find_own_finesses(state, giver, target, suitIndex, rank, looksDirect) {
+export function find_own_finesses(state, giver, target, suitIndex, rank, looksDirect, ignorePlayer = -1, selfRanks = []) {
 	// We cannot finesse ourselves
-	if (giver === state.ourPlayerIndex) {
+	if (giver === state.ourPlayerIndex && ignorePlayer === -1) {
 		return { feasible: false, connections: [] };
 	}
 
@@ -283,148 +290,216 @@ export function find_own_finesses(state, giver, target, suitIndex, rank, looksDi
 
 	/** @type {Connection[]} */
 	let connections = [];
-
-	let feasible = true;
 	let ignoreOrders = [], finesses = 0;
 
 	for (let next_rank = hypo_state.play_stacks[suitIndex] + 1; next_rank < rank; next_rank++) {
 		if (hypo_state.discard_stacks[suitIndex][next_rank - 1] === cardCount(hypo_state.suits[suitIndex], next_rank)) {
 			logger.info(`impossible to find ${logCard({suitIndex, rank: next_rank})}, both cards in trash`);
-			feasible = false;
-			break;
+			return { feasible: false, connections: [] };
 		}
+
+		const identity = { suitIndex, rank: next_rank };
+
+		/** @param {Connection[]} new_conns */
+		const addConnections = (new_conns) => {
+			let allHidden = true;
+			for (const connection of new_conns) {
+				connections.push(connection);
+
+				if (connection.hidden) {
+					hypo_state.play_stacks[connection.card.suitIndex]++;
+				}
+				else {
+					allHidden = false;
+
+					// Assume this is actually the card
+					connection.card.intersect('inferred', [identity]);
+					for (let i = 0; i < state.numPlayers; i++) {
+						card_elim(hypo_state, i, suitIndex, next_rank);
+					}
+				}
+
+				if (connection.type === 'finesse') {
+					finesses++;
+				}
+				ignoreOrders.push(connection.card.order);
+			}
+
+			if (allHidden) {
+				next_rank--;
+			}
+		};
 
 		// First, see if someone else has the connecting card
 		const currIgnoreOrders = ignoreOrders.concat(state.next_ignore[next_rank - hypo_state.play_stacks[suitIndex] - 1] ?? []);
-		const other_connecting = find_connecting(hypo_state, giver, target, suitIndex, next_rank, looksDirect, currIgnoreOrders);
+
+		const other_connecting = find_connecting(hypo_state, giver, target, suitIndex, next_rank, looksDirect, currIgnoreOrders, { knownOnly: [ignorePlayer] });
 		if (other_connecting.length > 0) {
 			connections = connections.concat(other_connecting);
 			ignoreOrders = ignoreOrders.concat(other_connecting.map(conn => conn.card.order));
+			continue;
 		}
-		else {
+
+		if (giver !== state.ourPlayerIndex) {
 			// Otherwise, try to find prompt in our hand
 			const prompt = our_hand.find_prompt(suitIndex, next_rank, hypo_state.suits, currIgnoreOrders);
 			logger.debug('prompt in slot', prompt ? our_hand.findIndex(c => c.order === prompt.order) + 1 : '-1');
 			if (prompt !== undefined) {
 				if (state.level === 1 && finesses >= 1) {
 					logger.warn('blocked prompt + finesse at level 1');
-					feasible = false;
-					break;
+					return { feasible: false, connections: [] };
 				}
 
 				if (prompt?.rewinded && playableAway(hypo_state, prompt.suitIndex, prompt.rank) === 0) {
 					if (state.level < LEVEL.INTERMEDIATE_FINESSES) {
 						logger.warn(`blocked hidden finesse at level ${state.level}`);
-						feasible = false;
-						break;
+						return { feasible: false, connections: [] };
 					}
 
 					logger.info('found hidden prompt', logCard(prompt), 'in our hand - still searching for', logCard({ suitIndex, rank: next_rank}));
-					connections.push({ type: 'known', reacting: state.ourPlayerIndex, card: prompt, hidden: true, self: true });
-					hypo_state.play_stacks[prompt.suitIndex]++;
-
-					ignoreOrders.push(prompt.order);
-					next_rank--;
+					addConnections([{ type: 'known', reacting: state.ourPlayerIndex, card: prompt, hidden: true, self: true, identity }]);
+					continue;
 				}
 				else if (prompt.identity() === undefined || prompt.matches(suitIndex, next_rank)) {
 					logger.info('found prompt in our hand');
-					connections.push({ type: 'prompt', reacting: hypo_state.ourPlayerIndex, card: prompt, self: true });
-
-					// Assume this is actually the card
-					prompt.intersect('inferred', [{suitIndex, rank: next_rank}]);
-					for (let i = 0; i < state.numPlayers; i++) {
-						card_elim(hypo_state, i, suitIndex, next_rank);
-					}
-					ignoreOrders.push(prompt.order);
+					addConnections([{ type: 'prompt', reacting: hypo_state.ourPlayerIndex, card: prompt, self: true, identity }]);
+					continue;
 				}
 			}
-			else {
+			else if (!selfRanks.includes(next_rank)) {
 				// Otherwise, try to find finesse in our hand
-				let finesse = our_hand.find_finesse(currIgnoreOrders);
-				logger.debug('finesse in slot', finesse ? our_hand.findIndex(c => c.order === finesse.order) + 1 : '-1');
-
-				if (finesse?.rewinded && playableAway(hypo_state, finesse.suitIndex, finesse.rank) === 0) {
-					if (state.level < LEVEL.INTERMEDIATE_FINESSES) {
-						logger.warn(`blocked layered finesse at level ${state.level}`);
-						feasible = false;
-						break;
+				const { feasible, connections: new_conns } = find_self_finesse(hypo_state, identity, currIgnoreOrders.slice(), finesses);
+				if (feasible) {
+					if (new_conns.length > 0) {
+						addConnections(new_conns);
+						continue;
 					}
-
-					logger.info('found layered finesse', logCard(finesse), 'in our hand - still searching for', logCard({ suitIndex, rank: next_rank}));
-					connections.push({ type: 'finesse', reacting: state.ourPlayerIndex, card: finesse, hidden: true, self: true });
-					hypo_state.play_stacks[finesse.suitIndex]++;
-
-					ignoreOrders.push(finesse.order);
-					next_rank--;
-					finesses++;
-				}
-				else if (finesse?.inferred.some(p => p.matches(suitIndex, next_rank)) && (finesse.identity() === undefined || finesse.matches(suitIndex, next_rank))) {
-					if (state.level === 1 && ignoreOrders.length >= 1) {
-						logger.warn(`blocked ${finesses >= 1 ? 'double finesse' : 'prompt + finesse'} at level 1`);
-						feasible = false;
-						break;
-					}
-
-					// We have some information about the next finesse
-					if (state.next_finesse.length > 0) {
-						for (const action of state.next_finesse) {
-							let index = our_hand.findIndex(c => c.order === our_hand.find_finesse(currIgnoreOrders).order);
-							const { list, clue } = action;
-
-							// Touching a matching card to the finesse - all untouched cards are layered
-							// Touching a non-matching card - all touched cards are layered
-							const matching = cardTouched({suitIndex, rank: next_rank}, state.suits, clue);
-							let touched = list.includes(our_hand[index].order);
-
-							while ((matching ? !touched : touched)) {
-								logger.info('adding layered finesse in our hand in slot', index + 1);
-								connections.push({ type: 'finesse', reacting: state.ourPlayerIndex, card: our_hand[index], hidden: true, self: true });
-
-								const playable_identities = hypo_state.hypo_stacks[state.ourPlayerIndex].map((stack_rank, index) => { return { suitIndex: index, rank: stack_rank + 1 }; });
-								our_hand[index].intersect('inferred', playable_identities);
-
-								ignoreOrders.push(our_hand[index].order);
-								currIgnoreOrders.push(our_hand[index].order);
-								index++;
-								if (index === our_hand.length) {
-									feasible = false;
-									break;
-								}
-								touched = list.includes(our_hand[index].order);
-							}
-						}
-
-						if (!feasible) {
-							break;
-						}
-						// Assume next card is the finesse target
-						finesse = our_hand.find_finesse(currIgnoreOrders);
-
-						// Layered finesse is imposible
-						if (finesse === undefined) {
-							logger.info(`couldn't find a valid finesse target after layers!`);
-							feasible = false;
-							break;
-						}
-					}
-
-					logger.info('found finesse in our hand');
-					connections.push({ type: 'finesse', reacting: state.ourPlayerIndex, card: finesse, self: true });
-
-					// Assume this is actually the card
-					finesse.intersect('inferred', [{suitIndex, rank: next_rank}]);
-					for (let i = 0; i < state.numPlayers; i++) {
-						card_elim(hypo_state, i, suitIndex, next_rank);
-					}
-					ignoreOrders.push(finesse.order);
-					finesses++;
 				}
 				else {
-					feasible = false;
-					break;
+					return { feasible: false, connections: [] };
 				}
 			}
 		}
+
+		// Use the ignoring player's hand
+		if (ignorePlayer !== -1) {
+			const their_hand = hypo_state.hands[ignorePlayer];
+			const prompt = their_hand.find_prompt(suitIndex, next_rank, state.suits, currIgnoreOrders);
+
+			if (prompt !== undefined) {
+				if (state.level === 1 && finesses >= 1) {
+					return { feasible: false, connections: [] };
+				}
+
+				if (prompt.identity({ symmetric: true }) === undefined || prompt.matches(suitIndex, next_rank)) {
+					addConnections([{ type: 'prompt', reacting: target, card: prompt, self: true, identity }]);
+					continue;
+				}
+			}
+			else {
+				const finesse = their_hand.find_finesse(currIgnoreOrders);
+
+				if (finesse?.inferred.some(p => p.matches(suitIndex, next_rank)) && (finesse.identity({ symmetric: true }) === undefined || finesse.matches(suitIndex, next_rank))) {
+					if (state.level === 1 && ignoreOrders.length >= 1) {
+						return { feasible: false, connections: [] };
+					}
+					addConnections([{ type: 'finesse', reacting: target, card: finesse, self: true, identity }]);
+					continue;
+				}
+			}
+
+			// Try finesse in our hand again (if we skipped it earlier to prefer ignoring player)
+			if (giver !== state.ourPlayerIndex && selfRanks.includes(next_rank)) {
+				const { feasible, connections: new_conns } = find_self_finesse(hypo_state, identity, currIgnoreOrders.slice(), finesses);
+				if (feasible) {
+					if (new_conns.length !== 0) {
+						addConnections(new_conns);
+						continue;
+					}
+				}
+				else {
+					return { feasible: false, connections: [] };
+				}
+			}
+		}
+
+		return { feasible: false, connections: [] };
 	}
-	return { feasible, connections };
+	return { feasible: true, connections };
+}
+
+/**
+ * @param {State} state
+ * @param {BasicCard} identity
+ * @param {number[]} ignoreOrders
+ * @param {number} finesses
+ * @returns {{ feasible: boolean, connections: Connection[] }}
+ */
+function find_self_finesse(state, identity, ignoreOrders, finesses) {
+	const our_hand = state.hands[state.ourPlayerIndex];
+	const { suitIndex, rank } = identity;
+
+	/** @type {Connection[]} */
+	const connections = [];
+
+	let finesse = our_hand.find_finesse(ignoreOrders);
+	logger.debug('finesse in slot', finesse ? our_hand.findIndex(c => c.order === finesse.order) + 1 : '-1');
+
+	if (finesse?.rewinded && playableAway(state, finesse.suitIndex, finesse.rank) === 0) {
+		if (state.level < LEVEL.INTERMEDIATE_FINESSES) {
+			logger.warn(`blocked layered finesse at level ${state.level}`);
+			return { feasible: false, connections: [] };
+		}
+
+		logger.info('found layered finesse', logCard(finesse), 'in our hand - still searching for', logCard(identity));
+		return { feasible: true, connections: [{ type: 'finesse', reacting: state.ourPlayerIndex, card: finesse, hidden: true, self: true, identity }] };
+	}
+
+	if (finesse?.inferred.some(p => p.matches(suitIndex, rank)) && (finesse.identity() === undefined || finesse.matches(suitIndex, rank))) {
+		if (state.level === 1 && ignoreOrders.length >= 1) {
+			logger.warn(`blocked ${finesses >= 1 ? 'double finesse' : 'prompt + finesse'} at level 1`);
+			return { feasible: false, connections: [] };
+		}
+
+		// We have some information about the next finesse
+		if (state.next_finesse.length > 0) {
+			for (const action of state.next_finesse) {
+				let index = our_hand.findIndex(c => c.order === our_hand.find_finesse(ignoreOrders).order);
+				const { list, clue } = action;
+
+				// Touching a matching card to the finesse - all untouched cards are layered
+				// Touching a non-matching card - all touched cards are layered
+				const matching = cardTouched(identity, state.suits, clue);
+				let touched = list.includes(our_hand[index].order);
+
+				while ((matching ? !touched : touched)) {
+					logger.info('adding layered finesse in our hand in slot', index + 1);
+					connections.push({ type: 'finesse', reacting: state.ourPlayerIndex, card: our_hand[index], hidden: true, self: true, identity });
+
+					const playable_identities = state.hypo_stacks[state.ourPlayerIndex].map((stack_rank, index) => { return { suitIndex: index, rank: stack_rank + 1 }; });
+					our_hand[index].intersect('inferred', playable_identities);
+
+					ignoreOrders.push(our_hand[index].order);
+					index++;
+					if (index === our_hand.length) {
+						return { feasible: false, connections: [] };
+					}
+					touched = list.includes(our_hand[index].order);
+				}
+			}
+			// Assume next card is the finesse target
+			finesse = our_hand.find_finesse(ignoreOrders);
+
+			// Layered finesse is imposible
+			if (finesse === undefined) {
+				logger.info(`couldn't find a valid finesse target after layers!`);
+				return { feasible: false, connections: [] };
+			}
+		}
+
+		logger.info('found finesse in our hand');
+		connections.push({ type: 'finesse', reacting: state.ourPlayerIndex, card: finesse, self: true, identity });
+	}
+
+	return { feasible: true, connections };
 }

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -1,0 +1,200 @@
+import { CLUE } from '../../../constants.js';
+import { Card } from '../../../basics/Card.js';
+import { determine_focus } from '../hanabi-logic.js';
+import { find_own_finesses } from './connecting-cards.js';
+import { isBasicTrash } from '../../../basics/hanabi-util.js';
+
+import logger from '../../../tools/logger.js';
+import { logCard, logConnection } from '../../../tools/log.js';
+import * as Utils from '../../../tools/util.js';
+
+/**
+ * @typedef {import('../../h-group.js').default} State
+ * @typedef {import('../../../types.js').ClueAction} ClueAction
+ * @typedef {import('../../../types.js').Connection} Connection
+ * @typedef {import('../../../types.js').BasicCard} BasicCard
+ * @typedef {import('../../../types.js').FocusPossibility} FocusPossibility
+ */
+
+/**
+ * Determines whether the receiver can infer the exact identity of the focused card.
+ * @param {{ connections: Connection[]}[]} all_connections
+ */
+export function inference_known(all_connections) {
+	if (all_connections.length > 1) {
+		return false;
+	}
+
+	const { connections } = all_connections[0];
+	return connections.length === 0 || connections.every(conn => conn.type === 'known' || (conn.type === 'playable' && conn.known));
+}
+
+/**
+ * Returns the inferred rank of the card given a set of connections on a particular suit.
+ * @param {State} state
+ * @param {number} suitIndex
+ * @param {Connection[]} connections
+ */
+export function inference_rank(state, suitIndex, connections) {
+	return state.play_stacks[suitIndex] + 1 + connections.filter(conn => !conn.hidden).length;
+}
+
+/**
+ * Adds all symmetric connections to the list of waiting connections in the state.
+ * @param {State} state
+ * @param {FocusPossibility[]} symmetric_connections
+ * @param {FocusPossibility[]} existing_connections
+ * @param {Card} focused_card
+ * @param {number} giver
+ */
+export function add_symmetric_connections(state, symmetric_connections, existing_connections, focused_card, giver) {
+	for (const sym of symmetric_connections) {
+		const { connections, suitIndex, rank } = sym;
+
+		// No connections required
+		if (connections.length === 0) {
+			continue;
+		}
+
+		// Matches an inference we have
+		if (existing_connections.some((conn) => conn.suitIndex === suitIndex && conn.rank === rank)) {
+			continue;
+		}
+
+		state.waiting_connections.push({ connections, focused_card, inference: { suitIndex, rank }, giver, action_index: state.actionList.length - 1 });
+	}
+}
+
+/**
+ * Returns all focus possibilities that the receiver could interpret from the clue.
+ * @param {State} state
+ * @param {ClueAction} action
+ * @param {boolean} looksSave
+ * @param {number[]} selfRanks 		The ranks needed to play by the target (as a self-finesse).
+ * @param {number} ownBlindPlays 	The number of blind plays we need to make in the actual connection.
+ */
+export function find_symmetric_connections(state, action, looksSave, selfRanks, ownBlindPlays) {
+	const { giver, list, target } = action;
+	const { focused_card } = determine_focus(state.hands[target], list, { beforeClue: true });
+
+	/** @type {FocusPossibility[]} */
+	const symmetric_connections = [];
+
+	let conn_save, min_blind_plays = 10;
+	let self_target = true;
+
+	for (const card of focused_card.inferred) {
+		if (isBasicTrash(state, card.suitIndex, card.rank)) {
+			continue;
+		}
+
+		const looksDirect = focused_card.identity({ symmetric: true }) === undefined && (		// Focus must be unknown AND
+			action.clue.type === CLUE.COLOUR ||												// Colour clue always looks direct
+			state.hypo_stacks[giver].some(stack => stack + 1 === action.clue.value) ||		// Looks like a play
+			looksSave);																		// Looks like a save
+
+		logger.collect();
+		const { feasible, connections } = find_own_finesses(state, giver, target, card.suitIndex, card.rank, looksDirect, target, selfRanks);
+		logger.flush(false);
+
+		if (feasible) {
+			// Starts with self-finesse or self-prompt on target
+			if (connections[0]?.reacting === target) {
+				const blind_plays = connections.filter(conn => conn.type === 'finesse' && conn.reacting === target).length;
+
+				if (self_target && blind_plays < min_blind_plays) {
+					conn_save = { connections, suitIndex: card.suitIndex, rank: inference_rank(state, card.suitIndex, connections) };
+					min_blind_plays = blind_plays;
+				}
+			}
+			// Doesn't start with self
+			else {
+				// Temp: if a connection with no self-component exists, don't consider any connection with a self-component
+				self_target = false;
+				const blind_plays = connections.filter(conn => conn.type === 'finesse' && conn.reacting === state.ourPlayerIndex).length;
+
+				if (blind_plays === ownBlindPlays) {
+					symmetric_connections.push({ connections, suitIndex: card.suitIndex, rank: inference_rank(state, card.suitIndex, connections) });
+				}
+			}
+		}
+	}
+
+	if (self_target && conn_save !== undefined) {
+		symmetric_connections.push(conn_save);
+	}
+
+	const sym_conn = symmetric_connections.map(conn => {
+		return {
+			connections: conn.connections.map(logConnection),
+			inference: logCard({ suitIndex: conn.suitIndex, rank: conn.rank })
+		};
+	});
+
+	logger.info('symmetric connections', sym_conn);
+	return symmetric_connections;
+}
+
+
+/**
+ * Helper function that applies the given connections on the given suit to the state (e.g. writing finesses).
+ * @param {State} state
+ * @param {Connection[]} connections
+ */
+export function assign_connections(state, connections) {
+	// let next_rank = state.play_stacks[suitIndex] + 1;
+	const hypo_stacks = state.hypo_stacks.slice();
+
+	for (const connection of connections) {
+		const { type, reacting, hidden, card: conn_card, known, identity } = connection;
+		// The connections can be cloned, so need to modify the card directly
+		const card = state.hands[reacting].findOrder(conn_card.order);
+
+		logger.info(`connecting on order ${conn_card.order} (${logCard(conn_card)}) as ${logCard(identity)} order ${card.order} type ${type}`);
+
+		// Save the old inferences in case the connection doesn't exist (e.g. not finesse)
+		if (!card.superposition) {
+			card.old_inferred = Utils.objClone(card.inferred);
+		}
+
+		if (type === 'finesse') {
+			card.finessed = true;
+			card.finesse_index = state.actionList.length;
+			card.hidden = hidden;
+		}
+
+		if (hidden) {
+			const playable_identities = hypo_stacks[reacting].map((stack_rank, index) => { return { suitIndex: index, rank: stack_rank + 1 }; });
+			card.intersect('inferred', playable_identities);
+
+			// Temporarily force update hypo stacks so that layered finesses are written properly (?)
+			if (card.identity() !== undefined) {
+				const { suitIndex: suitIndex2, rank: rank2 } = card.identity();
+				if (hypo_stacks[reacting][suitIndex2] + 1 !== rank2) {
+					logger.warn('trying to connect', logCard({ suitIndex: suitIndex2, rank: rank2 }), 'but hypo stacks at', hypo_stacks[suitIndex2]);
+				}
+				hypo_stacks[reacting][suitIndex2] = rank2;
+			}
+		}
+		else {
+			// There are multiple possible connections on this card
+			if (card.superposition) {
+				card.union('inferred', [identity]);
+			}
+			else {
+				if (!(type === 'playable' && !known)) {
+					card.inferred = [new Card(identity.suitIndex, identity.rank)];
+				}
+				card.superposition = true;
+			}
+		}
+
+		// Updating notes not on our turn
+		// There might be multiple possible inferences on the same card from a self component
+		// TODO: Examine why this originally had self only?
+		if (card.old_inferred.length > card.inferred.length && card.reasoning.at(-1) !== state.actionList.length - 1) {
+			card.reasoning.push(state.actionList.length - 1);
+			card.reasoning_turn.push(state.turn_count);
+		}
+	}
+}

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -1,5 +1,5 @@
 import { CLUE } from '../../../constants.js';
-import { determine_focus } from '../hanabi-logic.js';
+import { determine_focus, looksPlayable } from '../hanabi-logic.js';
 import { find_connecting } from './connecting-cards.js';
 import { isCritical, playableAway, visibleFind } from '../../../basics/hanabi-util.js';
 import logger from '../../../tools/logger.js';
@@ -177,9 +177,8 @@ function find_rank_focus(state, rank, action) {
 
 			let finesses = 0;
 
-			const looksPlayable = state.hypo_stacks[giver].some(stack => stack + 1 === rank);
 			let ignoreOrders = already_connected.concat(state.next_ignore[next_rank - state.play_stacks[suitIndex] - 1] ?? []);
-			let looksDirect = focused_card.identity({ symmetric: true }) === undefined && (looksSave || looksPlayable);
+			let looksDirect = focused_card.identity({ symmetric: true }) === undefined && (looksSave || looksPlayable(state, rank, giver, target, focused_card));
 			let connecting = find_connecting(hypo_state, giver, target, suitIndex, next_rank, looksDirect, ignoreOrders);
 
 			while (connecting.length !== 0) {

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -10,12 +10,7 @@ import * as Utils from '../../../tools/util.js';
  * @typedef {import('../../h-group.js').default} State
  * @typedef {import('../../../types.js').ClueAction} ClueAction
  * @typedef {import('../../../types.js').Connection} Connection
- * 
- * @typedef FocusPossibility
- * @property {number} suitIndex
- * @property {number} rank
- * @property {Connection[]} connections
- * @property {boolean} [save]
+ * @typedef {import('../../../types.js').FocusPossibility} FocusPossibility
  */
 
 /**
@@ -162,8 +157,8 @@ function find_rank_focus(state, rank, action) {
 
 	// Play clue
 	for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++) {
-		// Critical cards can never be given a play clue
-		if (isCritical(state, suitIndex, rank)) {
+		// Critical cards on chop can never be given a play clue
+		if (chop && isCritical(state, suitIndex, rank)) {
 			continue;
 		}
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -235,6 +235,7 @@ export function interpret_clue(state, action) {
 	const matched_correct = target === state.ourPlayerIndex || correct_match !== undefined;
 
 	const old_state = state.minimalCopy();
+	const old_inferred = focused_card.inferred;
 
 	// Card matches an inference and not a save/stall
 	// If we know the identity of the card, one of the matched inferences must also be correct before we can give this clue.
@@ -274,6 +275,7 @@ export function interpret_clue(state, action) {
 			for (const { connections } of symmetric_connections) {
 				assign_connections(state, connections);
 			}
+			focused_card.union('inferred', old_inferred.filter(inf => symmetric_connections.some(c => c.suitIndex === inf.suitIndex && c.rank === inf.rank)));
 			reset_superpositions(state);
 		}
 	}
@@ -398,6 +400,7 @@ export function interpret_clue(state, action) {
 				for (const { connections } of symmetric_connections) {
 					assign_connections(state, connections);
 				}
+				focused_card.union('inferred', old_inferred.filter(inf => symmetric_connections.some(c => c.suitIndex === inf.suitIndex && c.rank === inf.rank)));
 				reset_superpositions(state);
 			}
 		}

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -1,4 +1,5 @@
-import { getPace, isTrash } from '../../basics/hanabi-util.js';
+import { baseCount, getPace, isTrash, visibleFind } from '../../basics/hanabi-util.js';
+import { cardCount } from '../../variants.js';
 import logger from '../../tools/logger.js';
 import { logHand } from '../../tools/log.js';
 
@@ -135,4 +136,22 @@ export function minimum_clue_value(state) {
 	// -0.5 if 2 players (allows tempo clues to be given)
 	// -10 if endgame
 	return 1 - (state.numPlayers === 2 ? 0.5 : 0) - (inEndgame(state) ? 10 : 0);
+}
+
+/**
+ * @param {State} state
+ * @param {number} rank
+ * @param {number} giver
+ * @param {number} target
+ * @param {Card} focused_card
+ */
+export function looksPlayable(state, rank, giver, target, focused_card) {
+	return state.hypo_stacks[giver].some((stack, suitIndex) => {
+		const playable_identity = stack + 1 === rank;
+		const other_visibles = baseCount(state, suitIndex, rank) +
+			visibleFind(state, target, suitIndex, rank).filter(c => c.order !== focused_card.order).length;
+		const matching_inference = focused_card.inferred.some(inf => inf.suitIndex === suitIndex && inf.rank === rank);
+
+		return playable_identity && other_visibles < cardCount(state.suits[suitIndex], rank) && matching_inference;
+	});
 }

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -191,7 +191,7 @@ export function take_action(state) {
 	}
 
 	// Playing a connecting card or playing a 5
-	if (playable_cards.length > 0 && priority <= 3) {
+	if (best_playable_card !== undefined && priority <= 3) {
 		return { tableID, type: ACTION.PLAY, target: best_playable_card.order };
 	}
 
@@ -201,7 +201,7 @@ export function take_action(state) {
 	}
 
 	// Playable card with any priority
-	if (playable_cards.length > 0) {
+	if (best_playable_card !== undefined) {
 		return { tableID, type: ACTION.PLAY, target: best_playable_card.order };
 	}
 

--- a/src/conventions/h-hand.js
+++ b/src/conventions/h-hand.js
@@ -116,7 +116,7 @@ export class HGroup_Hand extends Hand {
 			return (all_crit ? rank * 5 : 0) + rank - this.state.hypo_stacks[this.playerIndex][suitIndex];
 		};
 
-		let max_dist = 0;
+		let max_dist = -1;
 
 		/** @type Card */
 		let furthest_card;

--- a/src/tools/log.js
+++ b/src/tools/log.js
@@ -9,6 +9,7 @@ import { globals } from './util.js';
  * @typedef {import('../types.js').Clue} Clue
  * @typedef {import('../types.js').Action} Action
  * @typedef {import('../types.js').PerformAction} PerformAction
+ * @typedef {import('../types.js').Connection} Connection
  */
 
 /**
@@ -179,4 +180,12 @@ export function logAction(action) {
 		default:
 			return JSON.stringify(action);
 	}
+}
+
+/**
+ * @param {Connection} connection
+ */
+export function logConnection(connection) {
+	const { type, reacting, identity, card } = connection;
+	return `${card.order} ${logCard(identity)} ${type} (${globals.state.playerNames[reacting]})`;
 }

--- a/src/tools/logger.js
+++ b/src/tools/logger.js
@@ -31,8 +31,12 @@ class Logger {
 	log(colour, ...args) {
 		if (this.accumulateDepth > 0) {
 			// Failsafe
-			if (this.buffer[this.accumulateDepth].length > 1000 || this.accumulateDepth > 10) {
-				throw new Error('stop.');
+			if (this.buffer[this.accumulateDepth].length > 2000) {
+				throw new Error('stop. buffer too large');
+			}
+
+			if (this.accumulateDepth > 10) {
+				throw new Error('stop. recursion too deep');
 			}
 
 			this.buffer[this.accumulateDepth].push({ colour, args });

--- a/src/tools/util.js
+++ b/src/tools/util.js
@@ -56,15 +56,33 @@ export function sendChat(tableID, msg) {
 	sendCmd('chat', { msg, room: `table${tableID}` });
 }
 
+const cmdQueue = [];
+let queueTimer;
+
 /**
  * Sends a game command to hanab.live with an object as data.
  * @param {string} command
  * @param {any} arg
  */
 export function sendCmd(command, arg) {
-	const cmd = command + ' ' + JSON.stringify(arg);
-	logger.debug('sending cmd ' + cmd);
+	cmdQueue.push(command + ' ' + JSON.stringify(arg));
+
+	if (queueTimer === undefined) {
+		emptyCmdQueue();
+	}
+}
+
+function emptyCmdQueue() {
+	if (cmdQueue.length === 0) {
+		queueTimer = undefined;
+		return;
+	}
+
+	const cmd = cmdQueue.shift();
 	globals.ws.send(cmd);
+	logger.debug('sending cmd', cmd);
+
+	queueTimer = setTimeout(emptyCmdQueue, 500);
 }
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -86,6 +86,8 @@ import { Card } from './basics/Card.js';
  * @property {number} rank
  * @property {Connection[]} connections
  * @property {boolean} [save]
+ *
+ * @typedef {FocusPossibility & {fake: boolean}} SymFocusPossibility
  * 
  * @typedef WaitingConnection
  * @property {Connection[]} connections
@@ -95,6 +97,7 @@ import { Card } from './basics/Card.js';
  * @property {{suitIndex: number, rank: number}} inference
  * @property {number} action_index
  * @property {boolean} [ambiguousPassback]
+ * @property {boolean} [fake]
  * 
  * @typedef Link
  * @property {Card[]} cards

--- a/src/types.js
+++ b/src/types.js
@@ -76,9 +76,16 @@ import { Card } from './basics/Card.js';
  * @property {'known' | 'playable' | 'prompt' | 'finesse' | 'terminate'} type
  * @property {number} reacting
  * @property {Card} card
+ * @property {BasicCard} identity
  * @property {boolean} [self]
  * @property {boolean} [hidden]
  * @property {boolean} [known]
+ * 
+ * @typedef FocusPossibility
+ * @property {number} suitIndex
+ * @property {number} rank
+ * @property {Connection[]} connections
+ * @property {boolean} [save]
  * 
  * @typedef WaitingConnection
  * @property {Connection[]} connections

--- a/test/h-group/level-1/special-moves.js
+++ b/test/h-group/level-1/special-moves.js
@@ -9,7 +9,6 @@ import HGroup from '../../../src/conventions/h-group.js';
 import { find_clues } from '../../../src/conventions/h-group/clue-finder/clue-finder.js';
 import logger from '../../../src/tools/logger.js';
 
-
 logger.setLevel(logger.LEVELS.ERROR);
 
 describe('other cases', () => {

--- a/test/h-group/level-2.js
+++ b/test/h-group/level-2.js
@@ -119,4 +119,119 @@ describe('asymmetric clues', () => {
 		assert.equal(state.hands[PLAYER.ALICE][0].inferred.length > 1, true);
 		assert.equal(state.hands[PLAYER.ALICE][0].finessed, false);
 	});
+
+	it('understands multiple interpretations when connecting through multiple possible cards in other hand', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['g2', 'b4', 'g3', 'r3'],
+			['g4', 'y3', 'r4', 'p2'],
+			['g1', 'g5', 'y1', 'b4']
+		], 2);
+
+		// Bob clues 1 to Donald.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [13,15], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 1, currentPlayerIndex: PLAYER.CATHY });
+
+		// Cathy clues 3 to Bob, connecting on g1 (Donald, playable) and g2 (Bob, finesse).
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 3 }, giver: PLAYER.CATHY, list: [5], target: PLAYER.BOB });
+		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.DONALD });
+
+		// Bob's slot 1 can be either g2 or y2, since he doesn't know which 1 is connecting.
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.BOB][0]), ['y2', 'g2'].map(expandShortCard));
+	});
+
+	it('prefers the least number of blind plays on target', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y3', 'b2', 'y4', 'r3'],
+			['g4', 'y3', 'r4', 'p2'],
+			['g1', 'y2', 'y5', 'b4']
+		], 2);
+
+		// y1 is played.
+		state.play_stacks = [0, 1, 0, 0, 0];
+
+		// Alice clues yellow to Donald, getting y2.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.YELLOW }, giver: PLAYER.ALICE, list: [13,14], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 1, currentPlayerIndex: PLAYER.BOB });
+
+		// Bob clues 1 to Donald, getting g1.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [15], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.CATHY });
+
+		// Cathy clues 4 to Bob, connecting on y2 (Donald, known) and y3 (Bob, finesse).
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 4 }, giver: PLAYER.CATHY, list: [5], target: PLAYER.BOB });
+		state.handle_action({ type: 'turn', num: 3, currentPlayerIndex: PLAYER.DONALD });
+
+		// Bob's slot 1 must be y3, since it only requires one blind play (y3) instead of two (g2,g3).
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.BOB][0]), ['y3'].map(expandShortCard));
+	});
+
+	it('includes the correct interpretation, even if it requires more blind plays', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['g2', 'g3', 'g4', 'r3'],
+			['g4', 'y3', 'r4', 'p2'],
+			['g1', 'y2', 'y5', 'b4']
+		], 2);
+
+		// y1 is played.
+		state.play_stacks = [0, 1, 0, 0, 0];
+
+		// Alice clues yellow to Donald, getting y2.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.YELLOW }, giver: PLAYER.ALICE, list: [13,14], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 1, currentPlayerIndex: PLAYER.BOB });
+
+		// Bob clues 1 to Donald, getting g1.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [15], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.CATHY });
+
+		// Cathy clues 4 to Bob, connecting on y2 (Donald, known) and y3 (Bob, finesse).
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 4 }, giver: PLAYER.CATHY, list: [5], target: PLAYER.BOB });
+		state.handle_action({ type: 'turn', num: 3, currentPlayerIndex: PLAYER.DONALD });
+
+		// Although y3 should still be preferred, the correct inference is g2 -> g3 double self-finesse.
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.BOB][0]), ['y3','g2'].map(expandShortCard));
+	});
+
+	it('connects when a card plays early', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['p5', 'y4', 'r1', 'b3'],
+			['p1', 'p2', 'y3', 'y1'],
+			['g1', 'g5', 'y1', 'b5']
+		], 2);
+
+		// Donald clues 2 to Alice, touching slot 4.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 2 }, giver: PLAYER.DONALD, list: [0], target: PLAYER.ALICE });
+		state.handle_action({ type: 'turn', num: 1, currentPlayerIndex: PLAYER.ALICE });
+
+		// Alice clues 1 to Donald, getting g1, y1.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [13,15], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.BOB });
+
+		// Bob clues 3 to Cathy, connecting on y1 (Donald, playable) and y2 (Alice, playable).
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 3 }, giver: PLAYER.BOB, list: [9], target: PLAYER.CATHY });
+		state.handle_action({ type: 'turn', num: 3, currentPlayerIndex: PLAYER.CATHY });
+
+		// The clued card is likely g3 or y3, since that requires the least number of blind plays.
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.CATHY][2]), ['y3', 'g3'].map(expandShortCard));
+
+		// Cathy gives a 5 Save to Donald.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 5 }, giver: PLAYER.CATHY, list: [12], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 4, currentPlayerIndex: PLAYER.DONALD });
+
+		// Donald plays y1 and draws r4.
+		state.handle_action({ type: 'play', playerIndex: PLAYER.DONALD, suitIndex: COLOUR.YELLOW, rank: 1, order: 13 });
+		state.handle_action({ type: 'draw', playerIndex: PLAYER.DONALD, suitIndex: COLOUR.RED, rank: 4, order: 16 });
+		state.handle_action({ type: 'turn', num: 5, currentPlayerIndex: PLAYER.ALICE });
+
+		// Alice plays y2 and draws b1.
+		state.handle_action({ type: 'play', playerIndex: PLAYER.ALICE, suitIndex: COLOUR.YELLOW, rank: 2, order: 0 });
+		state.handle_action({ type: 'draw', playerIndex: PLAYER.ALICE, suitIndex: COLOUR.BLUE, rank: 1, order: 17 });
+		state.handle_action({ type: 'turn', num: 6, currentPlayerIndex: PLAYER.BOB });
+
+		// y3 should be known, since y2 played before g1 played.
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.CATHY][2]), ['y3'].map(expandShortCard));
+	});
 });

--- a/test/h-group/level-2.js
+++ b/test/h-group/level-2.js
@@ -186,12 +186,12 @@ describe('asymmetric clues', () => {
 		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.BOB, list: [15], target: PLAYER.DONALD });
 		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.CATHY });
 
-		// Cathy clues 4 to Bob, connecting on y2 (Donald, known) and y3 (Bob, finesse).
+		// Cathy clues 4 to Bob, connecting on g2 (Bob, finesse) and g3 (Bob, finesse).
 		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 4 }, giver: PLAYER.CATHY, list: [5], target: PLAYER.BOB });
 		state.handle_action({ type: 'turn', num: 3, currentPlayerIndex: PLAYER.DONALD });
 
 		// Although y3 should still be preferred, the correct inference is g2 -> g3 double self-finesse.
-		assert.deepEqual(getRawInferences(state.hands[PLAYER.BOB][0]), ['y3','g2'].map(expandShortCard));
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.BOB][0]), ['g2','y3'].map(expandShortCard));
 	});
 
 	it('connects when a card plays early', () => {
@@ -210,7 +210,7 @@ describe('asymmetric clues', () => {
 		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 1 }, giver: PLAYER.ALICE, list: [13,15], target: PLAYER.DONALD });
 		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.BOB });
 
-		// Bob clues 3 to Cathy, connecting on y1 (Donald, playable) and y2 (Alice, playable).
+		// Bob clues 3 to Cathy, connecting on y1 (Donald, playable) and y2 (Alice, prompt).
 		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 3 }, giver: PLAYER.BOB, list: [9], target: PLAYER.CATHY });
 		state.handle_action({ type: 'turn', num: 3, currentPlayerIndex: PLAYER.CATHY });
 

--- a/test/h-group/level-2.js
+++ b/test/h-group/level-2.js
@@ -7,7 +7,6 @@ import { COLOUR, PLAYER, expandShortCard, getRawInferences, setup } from '../tes
 import HGroup from '../../src/conventions/h-group.js';
 import { CLUE } from '../../src/constants.js';
 import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
-import { logClue } from '../../src/tools/log.js';
 import logger from '../../src/tools/logger.js';
 
 logger.setLevel(logger.LEVELS.ERROR);
@@ -27,8 +26,6 @@ describe('self-finesse', () => {
 		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.GREEN }, giver: PLAYER.BOB, list: [14], target: PLAYER.CATHY });
 
 		const { play_clues } = find_clues(state);
-
-		logger.info(play_clues[PLAYER.BOB].map(clue => logClue(clue)));
 
 		// 3 to Bob is not a valid clue.
 		assert.equal(play_clues[PLAYER.BOB].some(clue => clue.type === CLUE.RANK && clue.value === 3), false);

--- a/test/h-group/level-5.js
+++ b/test/h-group/level-5.js
@@ -67,6 +67,7 @@ describe('ambiguous clues', () => {
 		], 5);
 
 		state.play_stacks = [1, 0, 1, 1, 0];
+		state.hypo_stacks = Array(3).fill([1, 0, 1, 1, 0]);
 
 		// Alice clues 2 to Cathy.
 		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 2 }, giver: PLAYER.ALICE, list: [12], target: PLAYER.CATHY });

--- a/test/h-group/level-5/ambiguous-finesses.js
+++ b/test/h-group/level-5/ambiguous-finesses.js
@@ -102,4 +102,26 @@ describe('ambiguous finesse', () => {
 		assert.equal(state.hands[PLAYER.ALICE][1].finessed, true);
 		assert.deepEqual(getRawInferences(state.hands[PLAYER.ALICE][1]), ['r1'].map(expandShortCard));
 	});
+
+	it('prefers hidden prompt over ambiguous', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['g3', 'b4', 'g4', 'r3'],
+			['g4', 'y3', 'r4', 'p2'],
+			['g2', 'y2', 'g5', 'b2']
+		], 5);
+
+		state.play_stacks = [0, 1, 1, 0, 0];
+
+		// Bob clues 2 to Donald.
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 2 }, giver: PLAYER.BOB, list: [12,14,15], target: PLAYER.DONALD });
+		state.handle_action({ type: 'turn', num: 1, currentPlayerIndex: PLAYER.CATHY });
+
+		// Cathy clues 4 to Bob, connecting on g2 (Donald, prompt) and g3 (Bob, finesse).
+		state.handle_action({ type: 'clue', clue: { type: CLUE.RANK, value: 4 }, giver: PLAYER.CATHY, list: [5], target: PLAYER.BOB });
+		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.DONALD });
+
+		// Bob's slot 1 can be either g3 or y3, since he doesn't know which 1 is connecting.
+		assert.deepEqual(getRawInferences(state.hands[PLAYER.BOB][0]), ['y3', 'g3'].map(expandShortCard));
+	});
 });

--- a/test/h-group/level-5/hidden-finesses.js
+++ b/test/h-group/level-5/hidden-finesses.js
@@ -209,7 +209,7 @@ describe('layered finesse', () => {
 		state.handle_action({ type: 'clue', clue: { type: CLUE.COLOUR, value: COLOUR.RED }, giver: PLAYER.CATHY, list: [8], target: PLAYER.BOB });
 		state.handle_action({ type: 'turn', num: 2, currentPlayerIndex: PLAYER.ALICE });
 
-		// Alice plays slot 1, which is revealed to be b1! Alice then draws y1.
+		// Alice plays slot 1, which is revealed to be b1! Alice then draws something random.
 		state.handle_action({ type: 'play', order: 4, playerIndex: PLAYER.ALICE, suitIndex: COLOUR.BLUE, rank: 1 });
 		state.handle_action({ type: 'draw', order: 16, suitIndex: -1, rank: -1, playerIndex: PLAYER.ALICE });
 		state.handle_action({ type: 'turn', num: 3, currentPlayerIndex: PLAYER.BOB });


### PR DESCRIPTION
This addition correctly simulates ambiguous clues from the target's perspective, to help us understand why they might not play into a finesse right away.

Some other misc changes that got pulled in:
- Bots now write notes on all cards, not only their own.
- Server commands are now rate-limited to 2 per second.
- Several assorted bug fixes, as usual