### PR TITLE
Adds variant support for many basic variants

### DIFF
--- a/src/basics.js
+++ b/src/basics.js
@@ -16,7 +16,7 @@ import { find_possibilities } from './basics/helper.js';
  */
 export function onClue(state, action) {
 	const { target, clue, list } = action;
-	const new_possible = find_possibilities(clue, state.suits);
+	const new_possible = find_possibilities(clue, state.variant);
 
 	for (const { order } of state.hands[target]) {
 		const c = state.hands[target].findOrder(order);

--- a/src/basics.js
+++ b/src/basics.js
@@ -66,7 +66,7 @@ export function onDiscard(state, action) {
 	}
 
 	// Discarded all copies of a card - the new max rank is (discarded rank - 1) if not already lower
-	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, state.variant, { suitIndex, rank }))
+	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.variant, { suitIndex, rank }))
 		state.max_ranks[suitIndex] = Math.min(state.max_ranks[suitIndex], rank - 1);
 
 	if (failed)

--- a/src/basics.js
+++ b/src/basics.js
@@ -66,7 +66,7 @@ export function onDiscard(state, action) {
 	}
 
 	// Discarded all copies of a card - the new max rank is (discarded rank - 1) if not already lower
-	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, { suitIndex, rank })) {
+	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, state.variant, { suitIndex, rank })) {
 		state.max_ranks[suitIndex] = Math.min(state.max_ranks[suitIndex], rank - 1);
 	}
 

--- a/src/basics/Hand.js
+++ b/src/basics/Hand.js
@@ -6,6 +6,7 @@ import { cardTouched } from '../variants.js';
  * @typedef {import('../types.js').Identity} Identity
  * @typedef {import('./Card.js').ActualCard} ActualCard
  * @typedef {import('./Card.js').MatchOptions} MatchOptions
+ * @typedef {import('../variants.js').Variant} Variant
  */
 
 /**
@@ -64,9 +65,9 @@ export class Hand extends Array {
 	/**
 	 * Returns an array of cards touched by the clue.
 	 * @param {BaseClue} clue
-	 * @param {string[]} suits
+	 * @param {Variant} variant
 	 */
-	clueTouched(clue, suits) {
-		return Array.from(this.filter(card => cardTouched(card, suits, clue)));
+	clueTouched(clue, variant) {
+		return Array.from(this.filter(card => cardTouched(card, variant, clue)));
 	}
 }

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -18,6 +18,7 @@ import { logPerformAction } from '../tools/log.js';
  * @typedef {import('../types.js').TurnAction} TurnAction
  * @typedef {import('../types.js').PlayAction} PlayAction
  * @typedef {import('../types.js').PerformAction} PerformAction
+ * @typedef {import('../variants.js').Variant} Variant
  */
 
 export class State {
@@ -67,9 +68,10 @@ export class State {
 	 * @param {string[]} playerNames
 	 * @param {number} ourPlayerIndex
 	 * @param {string[]} suits
+	 * @param {Variant} variant
 	 * @param {boolean} in_progress
 	 */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, in_progress) {
+	constructor(tableID, playerNames, ourPlayerIndex, suits, variant, in_progress) {
 		/** @type {number} */
 		this.tableID = tableID;
 		/** @type {string[]} */
@@ -82,11 +84,14 @@ export class State {
 		/** @type {string[]} */
 		this.suits = suits;
 
+		/** @type {Variant}} */
+		this.variant = variant;
+
 		this.in_progress = in_progress;
 
 		/** @type {number} */
 		this.cardsLeft = this.suits.reduce((acc, _, suitIndex) =>
-			acc + [1, 2, 3, 4, 5].reduce((cards, rank) => cards + cardCount(suits, { suitIndex, rank }), 0), 0);
+			acc + [1, 2, 3, 4, 5].reduce((cards, rank) => cards + cardCount(suits, variant, { suitIndex, rank }), 0), 0);
 
 		const all_possible = [];
 		for (let suitIndex = 0; suitIndex < this.suits.length; suitIndex++) {
@@ -123,7 +128,7 @@ export class State {
 	 * Returns a blank copy of the state, as if the game had restarted.
 	 */
 	createBlank() {
-		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.in_progress);
+		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.in_progress);
 		newState.notes = this.notes;
 		newState.rewinds = this.rewinds;
 		return newState;
@@ -133,7 +138,7 @@ export class State {
 	 * Returns a copy of the state with only minimal properties (cheaper than cloning).
 	 */
 	minimalCopy() {
-		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.in_progress);
+		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.in_progress);
 
 		if (this.copyDepth > 3) {
 			throw new Error('Maximum recursive depth reached.');

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -110,6 +110,7 @@ export class State {
 		}
 
 		this.common = new Player(-1, all_possible.slice(), all_possible.slice(), Array.from({ length: this.suits.length }, _ => 0));
+
 	}
 
 	get me() {

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -68,12 +68,11 @@ export class State {
 	 * @param {number} tableID
 	 * @param {string[]} playerNames
 	 * @param {number} ourPlayerIndex
-	 * @param {string[]} suits
 	 * @param {Variant} variant
 	 * @param {TableOptions} options
 	 * @param {boolean} in_progress
 	 */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, variant, options, in_progress) {
+	constructor(tableID, playerNames, ourPlayerIndex, variant, options, in_progress) {
 		/** @type {number} */
 		this.tableID = tableID;
 		/** @type {string[]} */
@@ -82,9 +81,6 @@ export class State {
 		this.numPlayers = playerNames.length;
 		/** @type {number} */
 		this.ourPlayerIndex = ourPlayerIndex;
-
-		/** @type {string[]} */
-		this.suits = suits;
 
 		/** @type {Variant}} */
 		this.variant = variant;
@@ -95,11 +91,11 @@ export class State {
 		this.in_progress = in_progress;
 
 		/** @type {number} */
-		this.cardsLeft = this.suits.reduce((acc, _, suitIndex) =>
-			acc + [1, 2, 3, 4, 5].reduce((cards, rank) => cards + cardCount(suits, variant, { suitIndex, rank }), 0), 0);
+		this.cardsLeft = this.variant.suits.reduce((acc, _, suitIndex) =>
+			acc + [1, 2, 3, 4, 5].reduce((cards, rank) => cards + cardCount(variant, { suitIndex, rank }), 0), 0);
 
 		const all_possible = [];
-		for (let suitIndex = 0; suitIndex < this.suits.length; suitIndex++) {
+		for (let suitIndex = 0; suitIndex < this.variant.suits.length; suitIndex++) {
 			this.play_stacks.push(0);
 			this.discard_stacks.push([0, 0, 0, 0, 0]);
 			this.max_ranks.push(5);
@@ -110,10 +106,10 @@ export class State {
 
 		for (let i = 0; i < this.numPlayers; i++) {
 			this.hands.push(new Hand());
-			this.players[i] = new Player(i, all_possible.slice(), all_possible.slice(), Array.from({ length: this.suits.length }, _ => 0));
+			this.players[i] = new Player(i, all_possible.slice(), all_possible.slice(), Array.from({ length: this.variant.suits.length }, _ => 0));
 		}
 
-		this.common = new Player(-1, all_possible.slice(), all_possible.slice(), Array.from({ length: this.suits.length }, _ => 0));
+		this.common = new Player(-1, all_possible.slice(), all_possible.slice(), Array.from({ length: this.variant.suits.length }, _ => 0));
 
 	}
 
@@ -133,7 +129,7 @@ export class State {
 	 * Returns a blank copy of the state, as if the game had restarted.
 	 */
 	createBlank() {
-		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.options, this.in_progress);
+		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.variant, this.options, this.in_progress);
 		newState.notes = this.notes;
 		newState.rewinds = this.rewinds;
 		return newState;
@@ -143,7 +139,7 @@ export class State {
 	 * Returns a copy of the state with only minimal properties (cheaper than cloning).
 	 */
 	minimalCopy() {
-		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.options, this.in_progress);
+		const newState = new State(this.tableID, this.playerNames, this.ourPlayerIndex, this.variant, this.options, this.in_progress);
 
 		if (this.copyDepth > 3)
 			throw new Error('Maximum recursive depth reached.');

--- a/src/basics/clue-result.js
+++ b/src/basics/clue-result.js
@@ -88,7 +88,7 @@ export function playables_result(state, player, hypo_player) {
 	}
 
 	// Count the number of finesses and newly known playable cards
-	for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++) {
+	for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++) {
 		for (let rank = player.hypo_stacks[suitIndex] + 1; rank <= hypo_player.hypo_stacks[suitIndex]; rank++) {
 			const { playerIndex, old_card, hypo_card } = find_card({ suitIndex, rank });
 

--- a/src/basics/hanabi-util.js
+++ b/src/basics/hanabi-util.js
@@ -45,7 +45,7 @@ export function baseCount(state, { suitIndex, rank }) {
  */
 export function unknownIdentities(state, player, identity) {
 	const visibleCount = state.hands.flat().filter(c => player.thoughts[c.order].matches(identity)).length;
-	return cardCount(state.suits, identity) - baseCount(state, identity) - visibleCount;
+	return cardCount(state.suits, state.variant, identity) - baseCount(state, identity) - visibleCount;
 }
 
 /**
@@ -54,7 +54,7 @@ export function unknownIdentities(state, player, identity) {
  * @param {Identity} identity
  */
 export function isCritical(state, { suitIndex, rank }) {
-	return state.discard_stacks[suitIndex][rank - 1] === (cardCount(state.suits, { suitIndex, rank }) - 1);
+	return state.discard_stacks[suitIndex][rank - 1] === (cardCount(state.suits, state.variant, { suitIndex, rank }) - 1);
 }
 
 /**

--- a/src/basics/hanabi-util.js
+++ b/src/basics/hanabi-util.js
@@ -1,4 +1,5 @@
-import { CLUE, HAND_SIZE } from '../constants.js';
+import { getHandSize } from './helper.js';
+import { CLUE } from '../constants.js';
 import { cardCount, cardTouched, isCluable } from '../variants.js';
 
 /**
@@ -45,7 +46,7 @@ export function baseCount(state, { suitIndex, rank }) {
  */
 export function unknownIdentities(state, player, identity) {
 	const visibleCount = state.hands.flat().filter(c => player.thoughts[c.order].matches(identity)).length;
-	return cardCount(state.suits, state.variant, identity) - baseCount(state, identity) - visibleCount;
+	return cardCount(state.variant, identity) - baseCount(state, identity) - visibleCount;
 }
 
 /**
@@ -54,7 +55,7 @@ export function unknownIdentities(state, player, identity) {
  * @param {Identity} identity
  */
 export function isCritical(state, { suitIndex, rank }) {
-	return state.discard_stacks[suitIndex][rank - 1] === (cardCount(state.suits, state.variant, { suitIndex, rank }) - 1);
+	return state.discard_stacks[suitIndex][rank - 1] === (cardCount(state.variant, { suitIndex, rank }) - 1);
 }
 
 /**
@@ -127,7 +128,7 @@ export function inEndgame(state) {
  * @param {ActualCard} card
  */
 export function inStartingHand(state, card) {
-	return card.order < state.numPlayers * (HAND_SIZE[state.numPlayers] + (state.options?.oneLessCard ? -1 : state.options?.oneExtraCard ? 1 : 0));
+	return card.order < state.numPlayers * getHandSize(state);
 }
 
 /**
@@ -187,7 +188,7 @@ export function direct_clues(state, target, card, options) {
 	const direct_clues = [];
 
 	if (!options?.excludeColour) {
-		for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++) {
+		for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++) {
 			const clue = { type: CLUE.COLOUR, value: suitIndex, target };
 
 			if (isCluable(state.variant, clue) && cardTouched(card, state.variant, clue))

--- a/src/basics/hanabi-util.js
+++ b/src/basics/hanabi-util.js
@@ -127,7 +127,7 @@ export function inEndgame(state) {
  * @param {ActualCard} card
  */
 export function inStartingHand(state, card) {
-	return card.order < state.numPlayers * HAND_SIZE[state.numPlayers];
+	return card.order < state.numPlayers * (HAND_SIZE[state.numPlayers] + (state.options?.oneLessCard ? -1 : state.options?.oneExtraCard ? 1 : 0));
 }
 
 /**

--- a/src/basics/hanabi-util.js
+++ b/src/basics/hanabi-util.js
@@ -193,7 +193,7 @@ export function direct_clues(state, target, card, options) {
 		for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++) {
 			const clue = { type: CLUE.COLOUR, value: suitIndex, target };
 
-			if (isCluable(state.suits, clue) && cardTouched(card, state.suits, clue)) {
+			if (isCluable(state.variant, clue) && cardTouched(card, state.variant, clue)) {
 				direct_clues.push(clue);
 			}
 		}
@@ -203,7 +203,7 @@ export function direct_clues(state, target, card, options) {
 		for (let rank = 1; rank <= 5; rank++) {
 			const clue = { type: CLUE.RANK, value: rank, target };
 
-			if (isCluable(state.suits, clue) && cardTouched(card, state.suits, clue)) {
+			if (isCluable(state.variant, clue) && cardTouched(card, state.variant, clue)) {
 				direct_clues.push(clue);
 			}
 		}

--- a/src/basics/helper.js
+++ b/src/basics/helper.js
@@ -1,4 +1,4 @@
-import { CLUE } from '../constants.js';
+import { CLUE, HAND_SIZE } from '../constants.js';
 import { cardTouched } from '../variants.js';
 import { visibleFind } from './hanabi-util.js';
 
@@ -49,7 +49,7 @@ export function all_valid_clues(state, target) {
 	for (let rank = 1; rank <= 5; rank++)
 		clues.push({ type: CLUE.RANK, value: rank, target });
 
-	for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++)
+	for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++)
 		clues.push({ type: CLUE.COLOUR, value: suitIndex, target });
 
 	return clues.filter(clue => hand.clueTouched(clue, state.variant).length > 0);
@@ -220,4 +220,12 @@ export function checkFix(state, oldThoughts, clueAction) {
 export function undo_hypo_stacks(state, { suitIndex, rank }) {
 	logger.info(`discarded useful card ${logCard({suitIndex, rank})}, setting hypo stack to ${rank - 1}`);
 	state.common.hypo_stacks[suitIndex] = Math.min(state.common.hypo_stacks[suitIndex], rank - 1);
+}
+
+/**
+ * Returns the hand size of the given state.
+ * @param {State} state
+ */
+export function getHandSize(state) {
+	return HAND_SIZE[state.numPlayers] + (state.options?.oneLessCard ? -1 : state.options?.oneExtraCard ? 1 : 0);
 }

--- a/src/basics/helper.js
+++ b/src/basics/helper.js
@@ -13,6 +13,7 @@ import { unknownIdentities } from './hanabi-util.js';
  * @typedef {import('../types.js').BaseClue} BaseClue
  * @typedef {import('../types.js').Clue} Clue
  * @typedef {import('../types.js').Identity} Identity
+ * @typedef {import('../variants.js').Variant} Variant
  */
 
 /**
@@ -31,10 +32,10 @@ export function all_identities(suits) {
 
 /**
  * @param {BaseClue} clue
- * @param {string[]} suits
+ * @param {Variant} variant
  */
-export function find_possibilities(clue, suits) {
-	return all_identities(suits).filter(id => cardTouched(id, suits, clue));
+export function find_possibilities(clue, variant) {
+	return all_identities(variant.suits).filter(id => cardTouched(id, variant, clue));
 }
 
 /**

--- a/src/basics/player-elim.js
+++ b/src/basics/player-elim.js
@@ -29,7 +29,7 @@ export function card_elim(state) {
 		const certain_cards = visibleFind(state, this, identity);
 
 		if (!this.all_possible.some(c => c.matches(identity)) ||
-			baseCount(state, identity) + certain_cards.length !== cardCount(state.suits, state.variant, identity)
+			baseCount(state, identity) + certain_cards.length !== cardCount(state.variant, identity)
 		)
 			continue;
 

--- a/src/basics/player-elim.js
+++ b/src/basics/player-elim.js
@@ -29,7 +29,7 @@ export function card_elim(state) {
 		const certain_cards = visibleFind(state, this, identity);
 
 		if (!this.all_possible.some(c => c.matches(identity)) ||
-			baseCount(state, identity) + certain_cards.length !== cardCount(state.suits, identity)
+			baseCount(state, identity) + certain_cards.length !== cardCount(state.suits, state.variant, identity)
 		) {
 			continue;
 		}

--- a/src/command-handler.js
+++ b/src/command-handler.js
@@ -203,7 +203,7 @@ export const handle = {
 		const variant = await getVariant(options.variantName);
 
 		// Initialize game state using convention set
-		state = new conventions[settings.convention](tableID, playerNames, ourPlayerIndex, variant.suits, true, settings.level);
+		state = new conventions[settings.convention](tableID, playerNames, ourPlayerIndex, variant.suits, variant.newID, true, settings.level);
 
 		Utils.globalModify({state});
 

--- a/src/command-handler.js
+++ b/src/command-handler.js
@@ -199,10 +199,10 @@ export const handle = {
 		const { tableID, playerNames, ourPlayerIndex, options } = data;
 		const variant = await getVariant(options.variantName);
 
-		await getShortForms(variant.suits);
+		await getShortForms(variant);
 
 		// Initialize game state using convention set
-		state = new conventions[settings.convention](tableID, playerNames, ourPlayerIndex, variant.suits, variant, options, true, settings.level);
+		state = new conventions[settings.convention](tableID, playerNames, ourPlayerIndex, variant, options, true, settings.level);
 
 		Utils.globalModify({state});
 

--- a/src/command-handler.js
+++ b/src/command-handler.js
@@ -1,4 +1,4 @@
-import { getVariant } from './variants.js';
+import { getShortForms, getVariant } from './variants.js';
 import logger from './tools/logger.js';
 import * as Utils from './tools/util.js';
 
@@ -202,8 +202,10 @@ export const handle = {
 		const { tableID, playerNames, ourPlayerIndex, options } = data;
 		const variant = await getVariant(options.variantName);
 
+		await getShortForms(variant.suits);
+
 		// Initialize game state using convention set
-		state = new conventions[settings.convention](tableID, playerNames, ourPlayerIndex, variant.suits, variant.newID, true, settings.level);
+		state = new conventions[settings.convention](tableID, playerNames, ourPlayerIndex, variant.suits, variant, true, settings.level);
 
 		Utils.globalModify({state});
 

--- a/src/conventions/h-group.js
+++ b/src/conventions/h-group.js
@@ -9,6 +9,10 @@ import { HGroup_Player } from './h-player.js';
 import * as Utils from '../tools/util.js';
 
 /**
+ * @typedef {import('../variants.js').Variant} Variant
+ */
+
+/**
  * @property {HGroup_Player[]} players
  */
 export default class HGroup extends State {
@@ -26,11 +30,12 @@ export default class HGroup extends State {
 	 * @param {string[]} playerNames
 	 * @param {number} ourPlayerIndex
 	 * @param {string[]} suits
+	 * @param {Variant} variant
 	 * @param {boolean} in_progress
 	 * @param {number} [level] 	The convention level (defaults to 1).
 	 */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, in_progress, level = 1) {
-		super(tableID, playerNames, ourPlayerIndex, suits, in_progress);
+	constructor(tableID, playerNames, ourPlayerIndex, suits, variant, in_progress, level = 1) {
+		super(tableID, playerNames, ourPlayerIndex, suits, variant, in_progress);
 
 		this.players = this.players.map(p =>
 			new HGroup_Player(p.playerIndex, p.all_possible, p.all_inferred, p.hypo_stacks, p.thoughts, p.links, p.unknown_plays, p.waiting_connections, p.elims));
@@ -46,14 +51,14 @@ export default class HGroup extends State {
 	}
 
 	createBlank() {
-		const blank = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.in_progress, this.level);
+		const blank = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.in_progress, this.level);
 		blank.notes = this.notes;
 		blank.rewinds = this.rewinds;
 		return blank;
 	}
 
 	minimalCopy() {
-		const newState = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.in_progress, this.level);
+		const newState = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.in_progress, this.level);
 
 		if (this.copyDepth > 3) {
 			throw new Error('Maximum recursive depth reached.');

--- a/src/conventions/h-group.js
+++ b/src/conventions/h-group.js
@@ -30,14 +30,13 @@ export default class HGroup extends State {
 	 * @param {number} tableID
 	 * @param {string[]} playerNames
 	 * @param {number} ourPlayerIndex
-	 * @param {string[]} suits
 	 * @param {Variant} variant
 	 * @param {TableOptions} options
 	 * @param {boolean} in_progress
 	 * @param {number} [level] 	The convention level (defaults to 1).
 	 */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, variant, options, in_progress, level = 1) {
-		super(tableID, playerNames, ourPlayerIndex, suits, variant, options, in_progress);
+	constructor(tableID, playerNames, ourPlayerIndex, variant, options, in_progress, level = 1) {
+		super(tableID, playerNames, ourPlayerIndex, variant, options, in_progress);
 
 		this.players = this.players.map(p =>
 			new HGroup_Player(p.playerIndex, p.all_possible, p.all_inferred, p.hypo_stacks, p.thoughts, p.links, p.unknown_plays, p.waiting_connections, p.elims));
@@ -53,14 +52,14 @@ export default class HGroup extends State {
 	}
 
 	createBlank() {
-		const blank = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.options, this.in_progress, this.level);
+		const blank = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.variant, this.options, this.in_progress, this.level);
 		blank.notes = this.notes;
 		blank.rewinds = this.rewinds;
 		return blank;
 	}
 
 	minimalCopy() {
-		const newState = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.options, this.in_progress, this.level);
+		const newState = new HGroup(this.tableID, this.playerNames, this.ourPlayerIndex, this.variant, this.options, this.in_progress, this.level);
 
 		if (this.copyDepth > 3)
 			throw new Error('Maximum recursive depth reached.');

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -87,12 +87,12 @@ function find_tcm(state, target, saved_cards, trash_card, play_clues) {
 
 	// Critical cards and unique 2s can be saved directly if touching all cards
 	if ((isCritical(state, chop) || (save2(state, state.me, chop) && clue_safe(state, state.me, { type: CLUE.RANK, value: 2, target }))) &&
-		(direct_clues(state, target, chop).some(clue => saved_cards.every(c => cardTouched(c, state.suits, clue))))
+		(direct_clues(state, target, chop).some(clue => saved_cards.every(c => cardTouched(c, state.variant, clue))))
 	) {
 		logger.info('prefer direct save');
 		return;
 	}
-	else if (play_clues.some(clue => saved_cards.every(c => cardTouched(c, state.suits, clue)))) {
+	else if (play_clues.some(clue => saved_cards.every(c => cardTouched(c, state.variant, clue)))) {
 		logger.info('prefer play clue to save');
 		return;
 	}
@@ -312,7 +312,7 @@ export function find_clues(state, options = {}) {
 
 		save_clues[target] = Utils.maxOn(saves.filter(c => c !== undefined), (save_clue) => {
 			const { type, value, target } = save_clue;
-			const list = hand.clueTouched(save_clue, state.suits).map(c => c.order);
+			const list = hand.clueTouched(save_clue, state.variant).map(c => c.order);
 			const hypo_state = state.simulate_clue({ type: 'clue', clue: { type, value }, giver: state.ourPlayerIndex, target, list });
 			const result = get_result(state, hypo_state, save_clue, state.ourPlayerIndex);
 

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -115,7 +115,7 @@ function find_tcm(state, target, saved_cards, trash_card, play_clues) {
 		// Ensure that the card will become known trash
 		const tcm = possible_clues.find(clue =>
 			(clue.type === CLUE.COLOUR && state.play_stacks[clue.value] === state.max_ranks[clue.value]) ||
-			(clue.type === CLUE.RANK   && state.suits.every((_, i) => (state.play_stacks[i] >= clue.value) || (state.max_ranks[i] < clue.value))));
+			(clue.type === CLUE.RANK   && state.variant.suits.every((_, i) => (state.play_stacks[i] >= clue.value) || (state.max_ranks[i] < clue.value))));
 
 		if (tcm !== undefined)
 			return Object.assign(tcm, { playable: false, cm: saved_cards, safe: true });

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -91,7 +91,7 @@ function find_tcm(state, target, saved_cards, trash_card, play_clues) {
 	const chop = saved_cards.at(-1);
 
 	// Critical cards and unique 2s can be saved directly if touching all cards
-	if ((isCritical(state, chop) || (save2(state, state.me, chop) && clue_safe(state, state.me, { type: CLUE.RANK, value: 2, target }))) &&
+	if ((isCritical(state, chop) || (save2(state, state.me, chop) && !state.variant.suits[chop.suitIndex].match(variantRegexes.brownish) && clue_safe(state, state.me, { type: CLUE.RANK, value: 2, target }))) &&
 		(direct_clues(state, target, chop).some(clue => saved_cards.every(c => cardTouched(c, state.variant, clue))))
 	) {
 		logger.info('prefer direct save');

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -122,7 +122,7 @@ function find_tcm(state, target, saved_cards, trash_card, play_clues) {
 		const possible_clues = direct_clues(state, target, trash_card);
 
 		// Ensure that the card will become known trash
-		const tcm = possible_clues.find(clue => !find_possibilities(clue, state.variant).some(c => isBasicTrash(state, c)));
+		const tcm = possible_clues.find(clue => find_possibilities(clue, state.variant).every(c => isBasicTrash(state, c)));
 
 		if (tcm !== undefined)
 			return Object.assign(tcm, { playable: false, cm: saved_cards, safe: true });

--- a/src/conventions/h-group/clue-finder/clue-safe.js
+++ b/src/conventions/h-group/clue-finder/clue-safe.js
@@ -17,7 +17,7 @@ import logger from '../../../tools/logger.js';
 export function clue_safe(state, player, clue) {
 	const { target } = clue;
 
-	const list = state.hands[target].clueTouched(clue, state.suits).map(c => c.order);
+	const list = state.hands[target].clueTouched(clue, state.variant).map(c => c.order);
 	const hypo_state = state.simulate_clue({ type: 'clue', giver: state.ourPlayerIndex, target, list, clue });
 	const hypo_player = hypo_state.players[player.playerIndex];
 

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -96,7 +96,7 @@ export function get_result(state, hypo_state, clue, giver, provisions = {}) {
 	const { target } = clue;
 	const hand = state.hands[target];
 
-	const touch = provisions.touch ?? hand.clueTouched(clue, state.suits);
+	const touch = provisions.touch ?? hand.clueTouched(clue, state.variant);
 	const list = provisions.list ?? touch.map(c => c.order);
 
 	const { focused_card } = determine_focus(hand, state.common, list, { beforeClue: true });
@@ -130,7 +130,7 @@ export function determine_clue(state, target, target_card, options) {
 	const results = [];
 
 	for (const clue of possible_clues) {
-		const touch = hand.clueTouched(clue, state.suits);
+		const touch = hand.clueTouched(clue, state.variant);
 		const list = touch.map(c => c.order);
 
 		const { focused_card, chop } = determine_focus(hand, state.common, list, { beforeClue: true });

--- a/src/conventions/h-group/clue-finder/fix-clues.js
+++ b/src/conventions/h-group/clue-finder/fix-clues.js
@@ -109,7 +109,7 @@ export function find_fix_clues(state, play_clues, save_clues, options = {}) {
 					// Go through all other clues to see if one fixes
 					for (const clue of other_clues) {
 						// The clue cannot touch the fixed card or it will look like just a fix
-						if (cardTouched(card, state.suits, clue)) {
+						if (cardTouched(card, state.variant, clue)) {
 							continue;
 						}
 
@@ -173,7 +173,7 @@ function duplication_known(state, card, _target) {
  * @param {(state: State, card: Card, target: number) => boolean} fix_criteria
  */
 function check_fixed(state, target, order, clue, fix_criteria) {
-	const touch = state.hands[target].clueTouched(clue, state.suits);
+	const touch = state.hands[target].clueTouched(clue, state.variant);
 
 	const action = /** @type {const} */ ({ type: 'clue', giver: state.ourPlayerIndex, target, list: touch.map(c => c.order), clue });
 

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -148,7 +148,7 @@ function find_unknown_connecting(state, giver, target, playerIndex, identity, ig
 export function find_connecting(state, giver, target, identity, looksDirect, ignoreOrders = [], options = {}) {
 	const { suitIndex, rank } = identity;
 
-	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, identity)) {
+	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, state.variant, identity)) {
 		logger.info(`all ${logCard(identity)} in trash`);
 		return [];
 	}

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -88,7 +88,7 @@ function find_known_connecting(state, giver, identity, ignoreOrders = []) {
  */
 function find_unknown_connecting(state, giver, target, playerIndex, identity, ignoreOrders = []) {
 	const hand = state.hands[playerIndex];
-	const prompt = state.common.find_prompt(hand, identity, state.suits, ignoreOrders);
+	const prompt = state.common.find_prompt(hand, identity, state.variant.suits, ignoreOrders);
 	const finesse = state.common.find_finesse(hand, ignoreOrders);
 
 	// Prompt takes priority over finesse
@@ -145,7 +145,7 @@ function find_unknown_connecting(state, giver, target, playerIndex, identity, ig
 export function find_connecting(state, giver, target, identity, looksDirect, ignoreOrders = [], options = {}) {
 	const { suitIndex, rank } = identity;
 
-	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, state.variant, identity)) {
+	if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.variant, identity)) {
 		logger.info(`all ${logCard(identity)} in trash`);
 		return [];
 	}
@@ -303,7 +303,7 @@ export function find_own_finesses(state, giver, target, { suitIndex, rank }, loo
 
 		if (giver !== state.ourPlayerIndex) {
 			// Otherwise, try to find prompt in our hand
-			const prompt = state.common.find_prompt(our_hand, next_identity, state.suits, currIgnoreOrders);
+			const prompt = state.common.find_prompt(our_hand, next_identity, state.variant.suits, currIgnoreOrders);
 			logger.debug('prompt in slot', prompt ? our_hand.findIndex(c => c.order === prompt.order) + 1 : '-1');
 			if (prompt !== undefined) {
 				if (state.level === 1 && finesses >= 1) {
@@ -343,7 +343,7 @@ export function find_own_finesses(state, giver, target, { suitIndex, rank }, loo
 		// Use the ignoring player's hand
 		if (ignorePlayer !== -1) {
 			const their_hand = hypo_state.hands[ignorePlayer];
-			const prompt = state.common.find_prompt(their_hand, next_identity, state.suits, currIgnoreOrders);
+			const prompt = state.common.find_prompt(their_hand, next_identity, state.variant.suits, currIgnoreOrders);
 
 			if (prompt !== undefined) {
 				if (state.level === 1 && finesses >= 1)

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -446,7 +446,7 @@ function find_self_finesse(state, identity, ignoreOrders, finesses) {
 
 				// Touching a matching card to the finesse - all untouched cards are layered
 				// Touching a non-matching card - all touched cards are layered
-				const matching = cardTouched(identity, state.suits, clue);
+				const matching = cardTouched(identity, state.variant, clue);
 				let touched = list.includes(our_hand[index].order);
 
 				while ((matching ? !touched : touched)) {
@@ -456,7 +456,7 @@ function find_self_finesse(state, identity, ignoreOrders, finesses) {
 
 					// Touching a non-matching card - we know exactly what playbable identities it should be
 					if (!matching) {
-						const possibilities = find_possibilities(clue, state.suits);
+						const possibilities = find_possibilities(clue, state.variant);
 						identities = identities.filter(card => possibilities.some(p => p.suitIndex === card.suitIndex && p.rank === rank));
 					}
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -5,6 +5,7 @@ import { isCritical, playableAway, visibleFind } from '../../../basics/hanabi-ut
 import logger from '../../../tools/logger.js';
 import { logCard, logConnections } from '../../../tools/log.js';
 import * as Utils from '../../../tools/util.js';
+import { variantRegexes } from '../../../variants.js';
 
 /**
  * @typedef {import('../../h-group.js').default} State
@@ -80,9 +81,12 @@ function find_colour_focus(state, suitIndex, action) {
 
 	// Save clue on chop (5 save cannot be done with colour)
 	if (chop) {
-		for (let rank = state.play_stacks[suitIndex] + 1; rank <= Math.min(state.max_ranks[suitIndex], 4); rank++) {
+		for (let rank = state.play_stacks[suitIndex] + 1; rank <= Math.min(state.max_ranks[suitIndex], 5); rank++) {
+			// Skip 5 possibility if the focused card does not include a brownish variant. (ex. No Variant games or a negative Brown card)
+			if (!state.common.thoughts[focused_card.order].possible.some(c => state.variant.suits[c.suitIndex].match(variantRegexes.brownish)))
+				continue;
 			// Determine if possible save on k2, k5 with colour
-			if (state.variant.suits[suitIndex] === 'Black' && (rank === 2 || rank === 5)) {
+			{if (state.variant.suits[suitIndex] === 'Black' && (rank === 2 || rank === 5)) {
 				let fill_ins = 0;
 
 				for (const card of state.hands[target]) {
@@ -98,7 +102,7 @@ function find_colour_focus(state, suitIndex, action) {
 				// Only touched/filled in 1 new card
 				if (fill_ins < 2)
 					continue;
-			}
+			}}
 
 			// Check if card is critical
 			if (isCritical(state, { suitIndex, rank }))

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -107,6 +107,10 @@ function find_colour_focus(state, suitIndex, action) {
 			// Check if card is critical
 			if (isCritical(state, { suitIndex, rank }))
 				focus_possible.push({ suitIndex, rank, save: true, connections: [] });
+
+			// Check if the card is a brownish-2
+			if (state.common.thoughts[focused_card.order].possible.some(c => state.variant.suits[c.suitIndex].match(variantRegexes.brownish) && c.rank === 2))
+				focus_possible.push({ suitIndex, rank, save: true, connections: [] });
 		}
 	}
 	return focus_possible;
@@ -237,16 +241,14 @@ export function find_focus_possible(state, action) {
 	let focus_possible = [];
 
 	if (clue.type === CLUE.COLOUR) {
-		const colour = state.variant.suits.includes('Rainbow') ? state.variant.suits.indexOf('Rainbow') : clue.value;
-		focus_possible = focus_possible.concat(find_colour_focus(state, colour, action));
+		const colours = state.variant.suits.filter(s => s.match(variantRegexes.rainbowish)).map(s => state.variant.suits.indexOf(s));
+		colours.push(clue.value);
+		colours.forEach(s => focus_possible = focus_possible.concat(find_colour_focus(state, s, action)));
 	}
 	else {
 		// Pink promise assumed
 		focus_possible = focus_possible.concat(find_rank_focus(state, clue.value, action));
 	}
-
-	if (state.variant.suits.includes('Omni'))
-		focus_possible = focus_possible.concat(find_colour_focus(state, state.variant.suits.indexOf('Omni'), action));
 
 	// Remove earlier duplicates (since save overrides play)
 	return focus_possible.filter((p1, index1) => {

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -83,10 +83,10 @@ function find_colour_focus(state, suitIndex, action) {
 	if (chop) {
 		for (let rank = state.play_stacks[suitIndex] + 1; rank <= Math.min(state.max_ranks[suitIndex], 5); rank++) {
 			// Skip 5 possibility if the focused card does not include a brownish variant. (ex. No Variant games or a negative Brown card)
-			if (!state.common.thoughts[focused_card.order].possible.some(c => state.variant.suits[c.suitIndex].match(variantRegexes.brownish)))
+			if (rank === 5 && !state.common.thoughts[focused_card.order].possible.some(c => state.variant.suits[c.suitIndex].match(variantRegexes.brownish)))
 				continue;
 			// Determine if possible save on k2, k5 with colour
-			{if (state.variant.suits[suitIndex] === 'Black' && (rank === 2 || rank === 5)) {
+			if (state.variant.suits[suitIndex] === 'Black' && (rank === 2 || rank === 5)) {
 				let fill_ins = 0;
 
 				for (const card of state.hands[target]) {
@@ -102,7 +102,7 @@ function find_colour_focus(state, suitIndex, action) {
 				// Only touched/filled in 1 new card
 				if (fill_ins < 2)
 					continue;
-			}}
+			}
 
 			// Check if card is critical
 			if (isCritical(state, { suitIndex, rank }))

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -82,7 +82,7 @@ function find_colour_focus(state, suitIndex, action) {
 	if (chop) {
 		for (let rank = state.play_stacks[suitIndex] + 1; rank <= Math.min(state.max_ranks[suitIndex], 4); rank++) {
 			// Determine if possible save on k2, k5 with colour
-			if (state.suits[suitIndex] === 'Black' && (rank === 2 || rank === 5)) {
+			if (state.variant.suits[suitIndex] === 'Black' && (rank === 2 || rank === 5)) {
 				let fill_ins = 0;
 
 				for (const card of state.hands[target]) {
@@ -125,7 +125,7 @@ function find_rank_focus(state, rank, action) {
 
 	// Save clue on chop
 	if (chop) {
-		for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++) {
+		for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++) {
 			const identity = { suitIndex, rank };
 
 			// Don't need to consider save on playable cards
@@ -133,7 +133,7 @@ function find_rank_focus(state, rank, action) {
 				continue;
 
 			// Don't consider save on k3, k4 with rank
-			if (state.suits[suitIndex] === 'Black' && (rank === 3 || rank === 4))
+			if (state.variant.suits[suitIndex] === 'Black' && (rank === 3 || rank === 4))
 				continue;
 
 			// Critical save or 2 save
@@ -144,7 +144,7 @@ function find_rank_focus(state, rank, action) {
 		}
 	}
 	// Play clue
-	for (let suitIndex = 0; suitIndex < state.suits.length; suitIndex++) {
+	for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++) {
 		let next_rank = state.play_stacks[suitIndex] + 1;
 
 		/** @type {Connection[]} */
@@ -233,7 +233,7 @@ export function find_focus_possible(state, action) {
 	let focus_possible = [];
 
 	if (clue.type === CLUE.COLOUR) {
-		const colour = state.suits.includes('Rainbow') ? state.suits.indexOf('Rainbow') : clue.value;
+		const colour = state.variant.suits.includes('Rainbow') ? state.variant.suits.indexOf('Rainbow') : clue.value;
 		focus_possible = focus_possible.concat(find_colour_focus(state, colour, action));
 	}
 	else {
@@ -241,8 +241,8 @@ export function find_focus_possible(state, action) {
 		focus_possible = focus_possible.concat(find_rank_focus(state, clue.value, action));
 	}
 
-	if (state.suits.includes('Omni'))
-		focus_possible = focus_possible.concat(find_colour_focus(state, state.suits.indexOf('Omni'), action));
+	if (state.variant.suits.includes('Omni'))
+		focus_possible = focus_possible.concat(find_colour_focus(state, state.variant.suits.indexOf('Omni'), action));
 
 	// Remove earlier duplicates (since save overrides play)
 	return focus_possible.filter((p1, index1) => {

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -108,7 +108,7 @@ export function interpret_tccm(state, oldCommon, target, list, focused_card) {
 
 	const chop = state.common.chop(state.hands[target], { afterClue: true });
 	const touched_cards = state.hands[target].filter(card => list.includes(card.order));
-	const prompt = oldCommon.find_prompt(state.hands[target], focused_card, state.suits);
+	const prompt = oldCommon.find_prompt(state.hands[target], focused_card, state.variant.suits);
 
 	if (chop === undefined ||											// Target was locked
 		touched_cards.some(card => card.newly_clued) ||					// At least one card touched was newly clued

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -102,7 +102,7 @@ export function rankLooksPlayable(state, rank, order) {
 			visibleFind(state, state.common, identity).filter(c => c.order !== order).length;
 		const matching_inference = state.common.thoughts[order].inferred.some(inf => inf.matches(identity));
 
-		return playable_identity && other_visibles < cardCount(state.suits, identity) && matching_inference;
+		return playable_identity && other_visibles < cardCount(state.suits, state.variant, identity) && matching_inference;
 	});
 }
 

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -117,7 +117,7 @@ export function rankLooksPlayable(state, rank, order) {
  */
 export function valuable_tempo_clue(state, player, clue, playables, focused_card) {
 	const { target } = clue;
-	const touch = state.hands[target].clueTouched(clue, state.suits);
+	const touch = state.hands[target].clueTouched(clue, state.variant);
 
 	if (touch.some(card => !card.clued)) {
 		return { tempo: false, valuable: false };

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -92,7 +92,7 @@ export function rankLooksPlayable(state, rank, order) {
 			visibleFind(state, state.common, identity).filter(c => c.order !== order).length;
 		const matching_inference = state.common.thoughts[order].inferred.some(inf => inf.matches(identity));
 
-		return playable_identity && other_visibles < cardCount(state.suits, state.variant, identity) && matching_inference;
+		return playable_identity && other_visibles < cardCount(state.variant, identity) && matching_inference;
 	});
 }
 
@@ -112,7 +112,7 @@ export function valuable_tempo_clue(state, player, clue, playables, focused_card
 	if (touch.some(card => !card.clued))
 		return { tempo: false, valuable: false };
 
-	const prompt = player.find_prompt(state.hands[target], focused_card, state.suits);
+	const prompt = player.find_prompt(state.hands[target], focused_card, state.variant.suits);
 
 	// No prompt exists for this card (i.e. it is a hard burn)
 	if (prompt === undefined)

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -188,7 +188,7 @@ export function take_action(state) {
 	}
 
 	// Sarcastic discard to someone else
-	if (state.level >= LEVEL.SARCASTIC && discards.length > 0) {
+	if (state.level >= LEVEL.SARCASTIC && discards.length > 0 && state.clue_tokens !== 8) {
 		const identity = discards[0].identity({ infer: true });
 		const duplicates = visibleFind(state, state.me, identity, { ignore: [state.ourPlayerIndex] }).filter(c => c.clued).map(c => state.me.thoughts[c.order]);
 
@@ -196,7 +196,6 @@ export function take_action(state) {
 		if (inEndgame(state) && duplicates.every(c => c.inferred.length === 0 || (c.inferred.every(inf => inf.matches(identity) || isBasicTrash(state, inf))))) {
 			return { tableID, type: ACTION.PLAY, target: discards[0].order };
 		}
-
 		return { tableID, type: ACTION.DISCARD, target: discards[0].order };
 	}
 
@@ -251,7 +250,7 @@ export function take_action(state) {
 	const play_clue_2p = best_play_clue ?? Utils.maxOn(stall_clues[1], clue => find_clue_value(clue.result));
 
 	const not_selfish = (clue) => {
-		const list = state.hands[nextPlayerIndex].clueTouched(clue, state.suits).map(c => c.order);
+		const list = state.hands[nextPlayerIndex].clueTouched(clue, state.variant).map(c => c.order);
 		const { focused_card } = determine_focus(state.hands[nextPlayerIndex], state.common, list, { beforeClue: true });
 		const { suitIndex } = focused_card;
 

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -109,7 +109,7 @@ function find_play_over_save(state, target, all_play_clues, locked, remainder_bo
 			}
 		}
 
-		const touches_chop = state.hands[target].clueTouched(clue, state.suits).some(c => c.order === state.common.chop(state.hands[target])?.order);
+		const touches_chop = state.hands[target].clueTouched(clue, state.variant).some(c => c.order === state.common.chop(state.hands[target])?.order);
 		if (!locked && touches_chop && clue_safe(state, state.me, clue)) {
 			play_clues.push({ clue, playables: [] });
 		}
@@ -206,7 +206,7 @@ export function find_urgent_actions(state, play_clues, save_clues, fix_clues, st
 				continue;
 			}
 
-			const list = state.hands[target].clueTouched(save, state.suits).map(c => c.order);
+			const list = state.hands[target].clueTouched(save, state.variant).map(c => c.order);
 			const hypo_state = state.simulate_clue({ type: 'clue', giver: state.ourPlayerIndex, list, clue: save, target });
 
 			// Give them a fix clue with known trash if possible (TODO: Re-examine if this should only be urgent fixes)
@@ -248,7 +248,7 @@ export function find_urgent_actions(state, play_clues, save_clues, fix_clues, st
 				let tccm = false;
 				for (const clue of stall_clues[1].filter(clue => clue.target === target)) {
 					const { playables } = clue.result;
-					const { focused_card } = determine_focus(hand, state.common, hand.clueTouched(clue, state.suits).map(c => c.order), { beforeClue: true });
+					const { focused_card } = determine_focus(hand, state.common, hand.clueTouched(clue, state.variant).map(c => c.order), { beforeClue: true });
 					const { tempo, valuable } = valuable_tempo_clue(state, state.common, clue, playables, focused_card);
 
 					if (tempo && !valuable && clue_safe(state, state.me, clue)) {

--- a/src/conventions/playful-sieve.js
+++ b/src/conventions/playful-sieve.js
@@ -7,6 +7,10 @@ import { update_turn } from './playful-sieve/update-turn.js';
 
 import * as Utils from '../tools/util.js';
 
+/**
+ * @typedef {import('../variants.js').Variant} Variant
+ */
+
 export default class PlayfulSieve extends State {
 	convention_name = 'PlayfulSieve';
 	interpret_clue = interpret_clue;
@@ -23,14 +27,15 @@ export default class PlayfulSieve extends State {
 	 * @param {string[]} playerNames
 	 * @param {number} ourPlayerIndex
 	 * @param {string[]} suits
+	 * @param {Variant} variant
 	 * @param {boolean} in_progress
 	 */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, in_progress) {
-		super(tableID, playerNames, ourPlayerIndex, suits, in_progress);
+	constructor(tableID, playerNames, ourPlayerIndex, suits, variant, in_progress) {
+		super(tableID, playerNames, ourPlayerIndex, suits, variant, in_progress);
 	}
 
 	createBlank() {
-		const blank = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.in_progress);
+		const blank = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.in_progress);
 		blank.notes = this.notes;
 		blank.rewinds = this.rewinds;
 		blank.locked_shifts = this.locked_shifts;
@@ -38,7 +43,7 @@ export default class PlayfulSieve extends State {
 	}
 
 	minimalCopy() {
-		const newState = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.in_progress);
+		const newState = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.in_progress);
 
 		if (this.copyDepth > 3) {
 			throw new Error('Maximum recursive depth reached.');

--- a/src/conventions/playful-sieve.js
+++ b/src/conventions/playful-sieve.js
@@ -27,17 +27,16 @@ export default class PlayfulSieve extends State {
 	 * @param {number} tableID
 	 * @param {string[]} playerNames
 	 * @param {number} ourPlayerIndex
-	 * @param {string[]} suits
 	 * @param {Variant} variant
 	 * @param {TableOptions} options
 	 * @param {boolean} in_progress
 	 */
-	constructor(tableID, playerNames, ourPlayerIndex, suits, variant, options, in_progress) {
-		super(tableID, playerNames, ourPlayerIndex, suits, variant, options, in_progress);
+	constructor(tableID, playerNames, ourPlayerIndex, variant, options, in_progress) {
+		super(tableID, playerNames, ourPlayerIndex, variant, options, in_progress);
 	}
 
 	createBlank() {
-		const blank = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.options, this.in_progress);
+		const blank = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.variant, this.options, this.in_progress);
 		blank.notes = this.notes;
 		blank.rewinds = this.rewinds;
 		blank.locked_shifts = this.locked_shifts;
@@ -45,7 +44,7 @@ export default class PlayfulSieve extends State {
 	}
 
 	minimalCopy() {
-		const newState = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.suits, this.variant, this.options, this.in_progress);
+		const newState = new PlayfulSieve(this.tableID, this.playerNames, this.ourPlayerIndex, this.variant, this.options, this.in_progress);
 
 		if (this.copyDepth > 3)
 			throw new Error('Maximum recursive depth reached.');

--- a/src/conventions/playful-sieve/action-helper.js
+++ b/src/conventions/playful-sieve/action-helper.js
@@ -17,7 +17,7 @@ import { logCard, logClue } from '../../tools/log.js';
  */
 export function get_result(state, clue) {
 	const partner = (state.ourPlayerIndex + 1) % state.numPlayers;
-	const touch = state.hands[partner].clueTouched(clue, state.suits);
+	const touch = state.hands[partner].clueTouched(clue, state.variant);
 
 	if (touch.length === 0) {
 		throw new Error(`Tried to get a result with a clue ${logClue(clue)} that touches no cards!`);
@@ -72,7 +72,7 @@ export function get_result(state, clue) {
  */
 export function clue_value(state, clue) {
 	const partner = (state.ourPlayerIndex + 1) % state.numPlayers;
-	const touch = state.hands[partner].clueTouched(clue, state.suits);
+	const touch = state.hands[partner].clueTouched(clue, state.variant);
 
 	if (touch.length === 0)
 		return -9999;

--- a/src/conventions/playful-sieve/fix-clues.js
+++ b/src/conventions/playful-sieve/fix-clues.js
@@ -41,7 +41,7 @@ export function find_fix_clue(state) {
 	}
 
 	for (const clue of clues) {
-		const touch = state.hands[partner].clueTouched(clue, state.suits);
+		const touch = state.hands[partner].clueTouched(clue, state.variant);
 
 		// Can't give empty clues
 		if (touch.length === 0) {

--- a/src/conventions/playful-sieve/take-action.js
+++ b/src/conventions/playful-sieve/take-action.js
@@ -182,7 +182,7 @@ export function take_action(state) {
 
 		if (safe_playables.length > 0) {
 			// Play playable that leads to closest card
-			const partner_lowest_ranks = state.suits.map(_ => 6);
+			const partner_lowest_ranks = state.variant.suits.map(_ => 6);
 
 			for (const card of state.hands[partner])
 				partner_lowest_ranks[card.suitIndex] = Math.min(partner_lowest_ranks[card.suitIndex], card.rank);

--- a/src/conventions/playful-sieve/take-action.js
+++ b/src/conventions/playful-sieve/take-action.js
@@ -119,7 +119,7 @@ export function take_action(state) {
 		}
 
 		for (const clue of clues) {
-			const touch = partner_hand.clueTouched(clue, state.suits);
+			const touch = partner_hand.clueTouched(clue, state.variant);
 
 			// Can't give empty clues or colour clues touching chop
 			if (touch.length === 0 || (clue.type === CLUE.COLOUR && touch.some(card => card.order === chop.order))) {

--- a/src/replay.js
+++ b/src/replay.js
@@ -77,7 +77,7 @@ async function main() {
 
 	await getShortForms(variant);
 
-	const state = new conventions[convention](Number(id), players, ourPlayerIndex, variant.suits, variant, options, false, Number(level ?? 1));
+	const state = new conventions[convention](Number(id), players, ourPlayerIndex, variant, options, false, Number(level ?? 1));
 
 	Utils.globalModify({state});
 

--- a/src/replay.js
+++ b/src/replay.js
@@ -5,7 +5,7 @@ import { ACTION, END_CONDITION, HAND_SIZE } from './constants.js';
 
 import HGroup from './conventions/h-group.js';
 import PlayfulSieve from './conventions/playful-sieve.js';
-import { getVariant } from './variants.js';
+import { getShortForms, getVariant } from './variants.js';
 import { initConsole } from './tools/console.js';
 import * as Utils from './tools/util.js';
 
@@ -81,7 +81,9 @@ async function main() {
 		throw new Error(`Convention ${convention} is not supported.`);
 	}
 
-	const state = new conventions[convention](Number(id), players, ourPlayerIndex, variant.suits, false, Number(level ?? 1));
+	await getShortForms(variant.suits);
+
+	const state = new conventions[convention](Number(id), players, ourPlayerIndex, variant.suits, variant, false, Number(level ?? 1));
 
 	Utils.globalModify({state});
 

--- a/src/replay.js
+++ b/src/replay.js
@@ -1,8 +1,9 @@
 import * as https from 'https';
 import * as fs from 'fs';
 
-import { ACTION, END_CONDITION, HAND_SIZE } from './constants.js';
+import { ACTION, END_CONDITION } from './constants.js';
 
+import { getHandSize } from './basics/helper.js';
 import HGroup from './conventions/h-group.js';
 import PlayfulSieve from './conventions/playful-sieve.js';
 import { getShortForms, getVariant } from './variants.js';
@@ -74,13 +75,13 @@ async function main() {
 	if (conventions[convention] === undefined)
 		throw new Error(`Convention ${convention} is not supported.`);
 
-	await getShortForms(variant.suits);
+	await getShortForms(variant);
 
 	const state = new conventions[convention](Number(id), players, ourPlayerIndex, variant.suits, variant, options, false, Number(level ?? 1));
 
 	Utils.globalModify({state});
 
-	const handSize = HAND_SIZE[state.numPlayers] + (options?.oneLessCard ? -1 : options?.oneExtraCard ? 1 : 0);
+	const handSize = getHandSize(state);
 
 	// Draw cards in starting hands
 	for (let playerIndex = 0; playerIndex < state.numPlayers; playerIndex++) {

--- a/src/self-play.js
+++ b/src/self-play.js
@@ -49,7 +49,7 @@ async function main() {
 		for (let rank = 1; rank <= 5; rank++) {
 			const identity = Object.freeze({ suitIndex, rank });
 
-			for (let i = 0; i < cardCount(variant.suits, identity); i++) {
+			for (let i = 0; i < cardCount(variant.suits, variant.newID, identity); i++) {
 				deck.push(identity);
 			}
 		}
@@ -96,7 +96,7 @@ async function main() {
 function simulate_game(playerNames, deck, suits, convention, level) {
 	/** @type {{ state: State, order: number }[]} */
 	const states = playerNames.map((_, index) => {
-		return { state: new conventions[convention](-1, playerNames, index, suits, false, level), order: 0 };
+		return { state: new conventions[convention](-1, playerNames, index, suits, 'R+Y+G+B+P', false, level), order: 0 };
 	});
 	Utils.globalModify({ state: states[0].state });
 

--- a/src/self-play.js
+++ b/src/self-play.js
@@ -14,6 +14,7 @@ import logger from './tools/logger.js';
  * @typedef {import('./types.js').Identity} Identity
  * @typedef {import('./types.js').Action} Action
  * @typedef {import('./types.js').PerformAction} PerformAction
+ * @typedef {import('./variants.js').Variant} Variant
  */
 
 const conventions = /** @type {const} */ ({
@@ -23,11 +24,11 @@ const conventions = /** @type {const} */ ({
 
 const playerNames = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily', 'Fred'];
 
-const noVar = {
+const noVar = /** @type {Variant} */ ({
 	"id": 0,
 	"name": "No Variant",
 	"suits": ["Red", "Yellow", "Green", "Blue", "Purple"]
-};
+});
 
 async function main() {
 	const { convention = 'HGroup', level: lStr = '1', games = '10', players: pStr = '2', seed, variant: vStr = 'No Variant' } = Utils.parse_args();

--- a/src/self-play.js
+++ b/src/self-play.js
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
 
+import { getHandSize } from './basics/helper.js';
 import HGroup from './conventions/h-group.js';
 import PlayfulSieve from './conventions/playful-sieve.js';
-import { ACTION, END_CONDITION, HAND_SIZE, MAX_H_LEVEL } from './constants.js';
+import { ACTION, END_CONDITION, MAX_H_LEVEL } from './constants.js';
 import { cardCount, getVariant } from './variants.js';
 import * as Utils from './tools/util.js';
 
@@ -52,7 +53,7 @@ async function main() {
 		for (let rank = 1; rank <= 5; rank++) {
 			const identity = Object.freeze({ suitIndex, rank });
 
-			for (let i = 0; i < cardCount(variant.suits, variant, identity); i++)
+			for (let i = 0; i < cardCount(variant, identity); i++)
 				deck.push(identity);
 		}
 	}
@@ -66,7 +67,7 @@ async function main() {
 		const shuffled = shuffle(deck, seed);
 
 		const { score, strikeout, actions } =
-			simulate_game(players, shuffled, variant.suits, /** @type {keyof typeof conventions} */ (convention), level);
+			simulate_game(players, shuffled, /** @type {keyof typeof conventions} */ (convention), level);
 
 		fs.writeFileSync(`seeds/${seed}.json`, JSON.stringify({ players, deck: shuffled, actions }));
 		console.log(score, strikeout);
@@ -76,7 +77,7 @@ async function main() {
 			const players = playerNames.slice(0, numPlayers);
 			const shuffled = shuffle(deck, `${i}`);
 			const { score, strikeout, actions } =
-				simulate_game(players, shuffled, variant.suits, /** @type {keyof typeof conventions} */ (convention), level);
+				simulate_game(players, shuffled, /** @type {keyof typeof conventions} */ (convention), level);
 
 			if (score !== 25)
 				fs.writeFileSync(`seeds/${i}.json`, JSON.stringify({ players, deck: shuffled, actions }));
@@ -91,18 +92,16 @@ async function main() {
  * Returns the score of the game.
  * @param {string[]} playerNames
  * @param {Identity[]} deck
- * @param {string[]} suits
  * @param {keyof typeof conventions} convention
  * @param {number} level
  */
-function simulate_game(playerNames, deck, suits, convention, level) {
-	const states = playerNames.map((_, index) => ({ state: new conventions[convention](-1, playerNames, index, suits, noVar, {}, false, level), order: 0 }));
+function simulate_game(playerNames, deck, convention, level) {
+	const states = playerNames.map((_, index) => ({ state: new conventions[convention](-1, playerNames, index, noVar, {}, false, level), order: 0 }));
 	Utils.globalModify({ state: states[0].state });
-
-	const handSize = HAND_SIZE[playerNames.length];
 
 	for (let stateIndex = 0; stateIndex < playerNames.length; stateIndex++) {
 		const { state } = states[stateIndex];
+		const handSize = getHandSize(state);
 
 		// Draw cards in starting hands
 		for (let playerIndex = 0; playerIndex < playerNames.length; playerIndex++) {
@@ -122,7 +121,7 @@ function simulate_game(playerNames, deck, suits, convention, level) {
 	/** @type {Pick<PerformAction, 'type' | 'target' | 'value'>[]} */
 	const actions = [];
 
-	while (endgameTurns !== 0 && _state.strikes !== 3 && _state.score !== _state.suits.length * 5) {
+	while (endgameTurns !== 0 && _state.strikes !== 3 && _state.score !== _state.variant.suits.length * 5) {
 		if (turn !== 0) {
 			states.forEach(({ state }) => {
 				Utils.globalModify({ state });

--- a/src/tools/log.js
+++ b/src/tools/log.js
@@ -37,7 +37,7 @@ export function logCard(card) {
 	else {
 		return '(unknown)';
 	}
-	return shortForms[globals.state.suits[suitIndex]] + rank + (append !== undefined ? ' ' + append : '');
+	return shortForms[suitIndex] + rank + (append !== undefined ? ' ' + append : '');
 }
 
 /**

--- a/src/tools/log.js
+++ b/src/tools/log.js
@@ -72,7 +72,7 @@ export function logClue(clue) {
 	if (clue === undefined)
 		return;
 
-	const value = (clue.type === CLUE.COLOUR || clue.type === ACTION.COLOUR) ? globals.state.suits[clue.value].toLowerCase() : clue.value;
+	const value = (clue.type === CLUE.COLOUR || clue.type === ACTION.COLOUR) ? globals.state.variant.suits[clue.value].toLowerCase() : clue.value;
 
 	return `(${value} to ${globals.state.playerNames[clue.target]})`;
 }
@@ -131,7 +131,7 @@ export function logAction(action) {
 			let clue_value;
 
 			if (clue.type === CLUE.COLOUR)
-				clue_value = state.suits[clue.value].toLowerCase();
+				clue_value = state.variant.suits[clue.value].toLowerCase();
 			else
 				clue_value = clue.value;
 

--- a/src/tools/util.js
+++ b/src/tools/util.js
@@ -311,3 +311,13 @@ export function nextIndex(arr, testFunc, startIndex) {
 	}
 	return -1;
 }
+
+/**
+ * Combines multiple regular expressions into one.
+ * 
+ * @param  {...RegExp} regexes 
+ * @returns {RegExp}
+ */
+export function combineRegex(...regexes) {
+	return new RegExp(regexes.map(re => re.source).join('|'));
+}

--- a/src/tools/util.js
+++ b/src/tools/util.js
@@ -267,14 +267,14 @@ export function performToAction(state, action, playerIndex, deck) {
 		case ACTION.RANK: {
 			const clue = { type: CLUE.RANK, value };
 			const hand = target === state.ourPlayerIndex ? get_own_hand(state, deck) : state.hands[target];
-			const list = hand.clueTouched(clue, state.suits).map(c => c.order);
+			const list = hand.clueTouched(clue, state.variant).map(c => c.order);
 
 			return { type: 'clue', giver: playerIndex, target, clue, list };
 		}
 		case ACTION.COLOUR: {
 			const clue = { type: CLUE.COLOUR, value };
 			const hand = target === state.ourPlayerIndex ? get_own_hand(state, deck) : state.hands[target];
-			const list = hand.clueTouched(clue, state.suits).map(c => c.order);
+			const list = hand.clueTouched(clue, state.variant).map(c => c.order);
 
 			return { type: 'clue', giver: playerIndex, target, clue, list };
 		}

--- a/src/variants.js
+++ b/src/variants.js
@@ -194,6 +194,7 @@ export function isCluable(variant, clue) {
 	if (type === CLUE.COLOUR && (
 		variant.suits[value].match(variantRegexes.whitish)
 		|| variant.suits[value].match(variantRegexes.rainbowish)
+		|| variant.suits[value].match(/Prism/)
 	))
 		return false;
 	if (type === CLUE.RANK && !(variant.clueRanks?.includes(value) ?? true))

--- a/src/variants.js
+++ b/src/variants.js
@@ -9,11 +9,13 @@ import { CLUE } from './constants.js';
  * @property {number} id
  * @property {string} name
  * @property {string[]} suits
+ * @property {string} newID
  * @property {number} [specialRank]
  * @property {boolean} [specialAllClueColours]
  * @property {boolean} [specialAllClueRanks]
  * @property {boolean} [specialNoClueColours]
  * @property {boolean} [specialNoClueRanks]
+ * @property {number} criticalRank
  */
 
 const variantsURL = 'https://raw.githubusercontent.com/Hanabi-Live/hanabi-live/main/packages/game/src/json/variants.json';
@@ -83,31 +85,32 @@ export function cardTouched(card, suits, clue) {
 	const { suitIndex, rank } = card;
 	const suit = suits[suitIndex];
 
-	if (suit === 'Null') {
+	if (suit === 'Null' || suit === 'Dark Null') {
 		return false;
 	}
-	else if (suit === 'Omni') {
+	else if (suit === 'Omni' || suit === 'Dark Omni') {
 		return true;
 	}
 
 	if (type === CLUE.COLOUR) {
-		if (suit === 'White') {
+		if (suit === 'White' || suit === 'Gray' || suit === 'Light Pink' || suit === 'Gray Pink') {
 			return false;
 		}
-		else if (suit === 'Rainbow') {
+		else if (suit === 'Rainbow' || suit === 'Dark Rainbow' || suit === 'Muddy Rainbow' || suit === 'Cocoa Rainbow') {
 			return true;
 		}
-		else if (suit === 'Prism') {
+		else if (suit === 'Prism' || suit === 'Dark Prism') {
+			// Something about this implementation does not seem right.
 			return (rank % suits.length - 1) === (value + 1);
 		}
 
 		return suitIndex === value;
 	}
 	else if (type === CLUE.RANK) {
-		if (suit === 'Brown') {
+		if (suit === 'Brown' || suit === 'Dark Brown' || suit === 'Muddy Rainbow' || suit === 'Cocoa Rainbow') {
 			return false;
 		}
-		else if (suit === 'Pink') {
+		else if (suit === 'Pink' || suit === 'Dark Pink' || suit === 'Light Pink' || suit === 'Gray Pink') {
 			return true;
 		}
 
@@ -123,7 +126,10 @@ export function cardTouched(card, suits, clue) {
 export function isCluable(suits, clue) {
 	const { type, value } = clue;
 
-	if (type === CLUE.COLOUR && ['Null', 'Omni', 'White', 'Rainbow', 'Prism'].includes(suits[value])) {
+	if (type === CLUE.COLOUR && [
+		'Null', 'Omni', 'White', 'Rainbow', 'Light Pink', 'Muddy Rainbow', 'Prism',
+		'Dark Null', 'Dark Omni', 'Gray', 'Dark Rainbow', 'Gray Pink', 'Cocoa Rainbow', 'Dark Prism'
+	].includes(suits[value])) {
 		return false;
 	}
 	return true;
@@ -132,11 +138,21 @@ export function isCluable(suits, clue) {
 /**
  * Returns the total number of cards for an identity.
  * @param {string[]} suits
+ * @param {Variant} variant
  * @param {Identity} identity
  */
-export function cardCount(suits, { suitIndex, rank }) {
-	if (suits[suitIndex] === 'Black') {
+export function cardCount(suits, variant, { suitIndex, rank }) {
+	if ([
+		'Dark Null', 'Dark Brown', 'Cocoa Rainbow',
+		'Gray', 'Black', 'Dark Rainbow',
+		'Gray Pink', 'Dark Pink', 'Dark Omni',
+		'Dark Prism'
+	].includes(suits[suitIndex])) {
 		return 1;
+	}
+
+	if (variant.criticalRank === rank) {
+		return [3, 2, 2, 1, 1][rank - 1];
 	}
 
 	return [3, 2, 2, 2, 1][rank - 1];

--- a/src/variants.js
+++ b/src/variants.js
@@ -23,7 +23,7 @@ import { CLUE } from './constants.js';
  */
 
 const variantsURL = 'https://raw.githubusercontent.com/Hanabi-Live/hanabi-live/main/packages/game/src/json/variants.json';
-const colorsURL = 'https://raw.githubusercontent.com/Hanabi-Live/hanabi-live/main/packages/game/src/json/suits.json';
+const coloursURL = 'https://raw.githubusercontent.com/Hanabi-Live/hanabi-live/main/packages/game/src/json/suits.json';
 
 /** @type {Promise<Variant[]>} */
 const variants_promise = new Promise((resolve, reject) => {
@@ -54,8 +54,8 @@ const variants_promise = new Promise((resolve, reject) => {
 });
 
 /** @type {Promise<Array>} */
-const colors_promise = new Promise((resolve, reject) => {
-	https.get(colorsURL, (res) => {
+const colours_promise = new Promise((resolve, reject) => {
+	https.get(coloursURL, (res) => {
 		const { statusCode } = res;
 
 		if (statusCode !== 200) {
@@ -94,26 +94,21 @@ export let shortForms = /** @type {string[]} */ (['r', 'y', 'g', 'b', 'p']);
 
 /**
  * Edits shortForms to have the correct acryonyms.
- * @param {string[]} suits
+ * @param {Variant} variant
  */
-export async function getShortForms(suits) {
-	const colors = await colors_promise;
+export async function getShortForms(variant) {
+	const colors = await colours_promise;
 	const abbreviations = [];
-	for (const suitName of suits) {
+	for (const suitName of variant.suits) {
 		if (['Black', 'Pink', 'Brown'].includes(suitName)) {
 			abbreviations.push(['k', 'i', 'n'][['Black', 'Pink', 'Brown'].indexOf(suitName)]);
 		} else {
 			const abbreviation = colors.find(color => color.name === suitName)?.abbreviation ?? suitName.charAt(0);
-			if (abbreviations.includes(abbreviation.toLowerCase())) {
-				for (const char of suitName) {
-					if (!abbreviations.includes(char)) {
-						abbreviations.push(char.toLowerCase());
-						break;
-					}
-				}
-			} else {
+			if (abbreviations.includes(abbreviation.toLowerCase()))
+				abbreviations.push(suitName.toLowerCase().split('').find(char => !abbreviations.includes(char)));
+			else
 				abbreviations.push(abbreviation.toLowerCase());
-			}
+
 		}
 	}
 	shortForms = abbreviations;
@@ -205,17 +200,16 @@ export function isCluable(variant, clue) {
 
 /**
  * Returns the total number of cards for an identity.
- * @param {string[]} suits
  * @param {Variant} variant
  * @param {Identity} identity
  */
-export function cardCount(suits, variant, { suitIndex, rank }) {
+export function cardCount(variant, { suitIndex, rank }) {
 	if ([
 		'Dark Null', 'Dark Brown', 'Cocoa Rainbow',
 		'Gray', 'Black', 'Dark Rainbow',
 		'Gray Pink', 'Dark Pink', 'Dark Omni',
 		'Dark Prism'
-	].includes(suits[suitIndex]))
+	].includes(variant.suits[suitIndex]))
 		return 1;
 
 	if (variant.criticalRank === rank)

--- a/src/variants.js
+++ b/src/variants.js
@@ -143,7 +143,7 @@ export function cardTouched(card, variant, clue) {
 				'Rainbow', 'Dark Rainbow', 'Muddy Rainbow', 'Cocoa Rainbow',
 				'Prism', 'Dark Prism'
 			].includes(s)).length;
-			return (rank % (variant.suits.length - colourlessCount)) === (value - 1);
+			return ((rank - 1) % (variant.suits.length - colourlessCount)) === value;
 		}
 
 		if (rank === variant.specialRank) {

--- a/src/variants.js
+++ b/src/variants.js
@@ -14,7 +14,12 @@ import { CLUE } from './constants.js';
  * @property {boolean} [specialRankAllClueRanks]
  * @property {boolean} [specialRankNoClueColors]
  * @property {boolean} [specialRankNoClueRanks]
+ * @property {boolean} [specialRankDeceptive]
+ * @property {boolean} [chimneys]
+ * @property {boolean} [funnels]
  * @property {number} [criticalRank]
+ * @property {number} [specialRank]
+ * @property {number[]} [clueRanks]
  */
 
 const variantsURL = 'https://raw.githubusercontent.com/Hanabi-Live/hanabi-live/main/packages/game/src/json/variants.json';
@@ -164,9 +169,17 @@ export function cardTouched(card, variant, clue) {
 		if (rank === variant.specialRank) {
 			if (variant.specialRankAllClueRanks)
 				return true;
-			else if (variant.specialRankNoClueRanks)
+			if (variant.specialRankNoClueRanks)
 				return false;
+
+			if (variant.specialRankDeceptive)
+				return (suitIndex % 4) + (variant.specialRank === 1 ? 2 : 1) === value;
 		}
+
+		if (variant.chimneys)
+			return rank >= value;
+		if (variant.funnels)
+			return rank <= value;
 
 		return rank === value;
 	}
@@ -185,7 +198,7 @@ export function isCluable(variant, clue) {
 		'Dark Null', 'Dark Omni', 'Gray', 'Dark Rainbow', 'Gray Pink', 'Cocoa Rainbow', 'Dark Prism'
 	].includes(variant.suits[value]))
 		return false;
-	if (type === CLUE.RANK && value === variant.specialRank && (variant.specialRankAllClueRanks || variant.specialRankNoClueRanks))
+	if (type === CLUE.RANK && !(variant.clueRanks?.includes(value) ?? true))
 		return false;
 	return true;
 }

--- a/src/variants.js
+++ b/src/variants.js
@@ -141,8 +141,12 @@ export function cardTouched(card, variant, clue) {
 			return true;
 		}
 		else if (suit === 'Prism' || suit === 'Dark Prism') {
-			// TODO: Fix implementation of prism touch for complex variants (ex. Prism & Dark Prism)
-			return (rank % variant.suits.length - 1) === (value + 1);
+			const colourlessCount = variant.suits.filter(s => [
+				'White', 'Gray', 'Light Pink', 'Gray Pink',
+				'Rainbow', 'Dark Rainbow', 'Muddy Rainbow', 'Cocoa Rainbow',
+				'Prism', 'Dark Prism'
+			].includes(s)).length;
+			return (rank % (variant.suits.length - colourlessCount)) === (value - 1);
 		}
 
 		if (rank === variant.specialRank) {

--- a/test/conventionless/basic_prism.js
+++ b/test/conventionless/basic_prism.js
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { PLAYER, setup, takeTurn } from '../test-utils.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { isCluable } from '../../src/variants.js';
+
+import logger from '../../src/tools/logger.js';
+import { CLUE } from '../../src/constants.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+// TODO: Make this actually conventionless and not dependant on the HGroup conventions?
+
+describe('prism cluing', () => {
+	it('cannot clue prism', () => {
+		assert.ok(!isCluable(
+			{'id': 1465, 'name': 'Prism (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Prism']},
+			{
+				type: CLUE.COLOUR,
+				value: 4,
+			}
+		));
+	});
+
+	it('understands prism touch', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 1465, 'name': 'Prism (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Prism']}
+		},
+		);
+
+		takeTurn(state, 'Bob clues red to Alice (slot 1)');
+		[1, 5].forEach(r =>
+			assert.ok(state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: r})))
+		);
+		[2, 3, 4].forEach(r =>
+			assert.ok(!state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: r})))
+		);
+
+		takeTurn(state, 'Alice clues blue to Bob');
+
+		takeTurn(state, 'Bob clues green to Alice (slot 2)');
+		assert.ok(state.common.thoughts[3].possible.some(c => c.matches({suitIndex: 4, rank: 3})));
+		[1, 2, 4, 5].forEach(r =>
+			assert.ok(!state.common.thoughts[3].possible.some(c => c.matches({suitIndex: 4, rank: r})))
+		);
+	});
+});

--- a/test/conventionless/basic_variants.js
+++ b/test/conventionless/basic_variants.js
@@ -1,0 +1,169 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { PLAYER, setup, takeTurn } from '../test-utils.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { isCluable } from '../../src/variants.js';
+import { isCritical } from '../../src/basics/hanabi-util.js';
+
+import logger from '../../src/tools/logger.js';
+import { CLUE } from '../../src/constants.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+// TODO: Make this actually conventionless and not dependant on the HGroup conventions?
+
+describe('rainbow', () => {
+	it('has rainbow possibilities from color clues', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 16, 'name': 'Rainbow (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Rainbow']}
+		},
+		);
+
+		takeTurn(state, 'Bob clues red to Alice (slot 1)');
+
+		assert.ok(state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: 1})));
+	});
+
+	it('excludes rainbow possibilities from color clues', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g3', 'p1', 'b3', 'b2', 'b5']
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 16, 'name': 'Rainbow (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Rainbow']}
+		},
+		);
+
+		takeTurn(state, 'Bob clues red to Alice (slot 5)');
+
+		assert.ok(!state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: 1})));
+	});
+
+	it('cannot clue rainbow', () => {
+		assert.ok(!isCluable(
+			{'id': 16, 'name': 'Rainbow (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Rainbow']},
+			{
+				type: CLUE.COLOUR,
+				value: 4,
+			}
+		));
+	});
+});
+
+describe('pink', () => {
+	it('has pink possibilities from number clues', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 107, 'name': 'Pink (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Pink']}
+		},
+		);
+
+		takeTurn(state, 'Bob clues 1 to Alice (slot 1)');
+
+		assert.ok(state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: 5})));
+	});
+
+	it('excludes pink possibilities from number clues', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 107, 'name': 'Pink (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Pink']}
+		},
+		);
+
+		takeTurn(state, 'Bob clues 1 to Alice (slot 5)');
+
+		assert.ok(!state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: 5})));
+	});
+
+	it('can clue pink', () => {
+		assert.ok(isCluable(
+			{'id': 107, 'name': 'Pink (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Pink']},
+			{
+				type: CLUE.COLOUR,
+				value: 4,
+			}
+		));
+	});
+});
+
+describe('white', () => {
+	it('eliminates white possibilities from color clues', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 22, 'name': 'White (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'White']}
+		},
+		);
+
+		takeTurn(state, 'Bob clues red to Alice (slot 1)');
+
+		assert.ok(!state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: 1})));
+	});
+
+	it('cannot clue white', () => {
+		assert.ok(!isCluable(
+			{'id': 22, 'name': 'White (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'White']},
+			{
+				type: CLUE.COLOUR,
+				value: 4,
+			}
+		));
+	});
+});
+
+describe('black', () => {
+	it('sees only black as critical', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 21, 'name': 'Black (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Black']}
+		},
+		);
+
+		assert.ok(isCritical(state, {suitIndex: 4, rank: 1}));
+		assert.ok(!isCritical(state, {suitIndex: 0, rank: 1}));
+	});
+
+	it('can clue black', () => {
+		assert.ok(isCluable(
+			{'id': 21, 'name': 'Black (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Black']},
+			{
+				type: CLUE.COLOUR,
+				value: 4,
+			}
+		));
+	});
+});

--- a/test/conventionless/basic_variants.js
+++ b/test/conventionless/basic_variants.js
@@ -14,7 +14,7 @@ logger.setLevel(logger.LEVELS.ERROR);
 // TODO: Make this actually conventionless and not dependant on the HGroup conventions?
 
 describe('rainbow', () => {
-	it('has rainbow possibilities from color clues', () => {
+	it('has rainbow possibilities from colour clues', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['g2', 'b1', 'r2', 'r3', 'g5'],
@@ -32,7 +32,7 @@ describe('rainbow', () => {
 		assert.ok(state.common.thoughts[4].possible.some(c => c.matches({suitIndex: 4, rank: 1})));
 	});
 
-	it('excludes rainbow possibilities from color clues', () => {
+	it('excludes rainbow possibilities from colour clues', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['g3', 'p1', 'b3', 'b2', 'b5']
@@ -110,7 +110,7 @@ describe('pink', () => {
 });
 
 describe('white', () => {
-	it('eliminates white possibilities from color clues', () => {
+	it('eliminates white possibilities from colour clues', () => {
 		const state = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['g2', 'b1', 'r2', 'r3', 'g5'],

--- a/test/conventionless/dark_variants.js
+++ b/test/conventionless/dark_variants.js
@@ -1,0 +1,35 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { setup } from '../test-utils.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { isCritical } from '../../src/basics/hanabi-util.js';
+
+import logger from '../../src/tools/logger.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+// TODO: Make this actually conventionless and not dependant on the HGroup conventions?
+
+describe('dark variants', () => {
+	it('sees dark variants as critical', () => {
+		for (const variant of [
+			'Dark Null', 'Dark Brown', 'Cocoa Rainbow',
+			'Gray', 'Black', 'Dark Rainbow',
+			'Gray Pink', 'Dark Pink', 'Dark Omni',
+			'Dark Prism'
+		]) {
+			const state = setup(HGroup, [
+				['xx', 'xx', 'xx', 'xx', 'xx'],
+				['g2', 'b1', 'r2', 'r3', 'g5'],
+			], {
+				level: 1,
+				play_stacks: [0, 0, 0, 0, 0],
+				clue_tokens: 8,
+				variant: {'id': -1, 'name': '...', 'suits': ['Red', 'Yellow', 'Green', 'Blue', variant]}
+			},
+			);
+			assert.ok(isCritical(state, {suitIndex: 4, rank: 1}));
+		}
+	});
+});

--- a/test/h-group/variants/black-convs.js
+++ b/test/h-group/variants/black-convs.js
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { PLAYER, setup, takeTurn } from '../../test-utils.js';
+import HGroup from '../../../src/conventions/h-group.js';
+
+import logger from '../../../src/tools/logger.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+describe('save clue interpretation', () => {
+	it('understands k2/5 save with black for multiple touches', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 21, 'name': 'Black (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Black']}
+		});
+
+		takeTurn(state, 'Bob clues black to Alice (slots 4,5)');
+
+		assert.ok(state.common.thoughts[0].inferred.some(c => c.matches({suitIndex: 4, rank: 2})));
+		assert.ok(state.common.thoughts[0].inferred.some(c => c.matches({suitIndex: 4, rank: 5})));
+	});
+
+	it('understands k2/5 save with black for filling in', () => {
+		const state = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b1', 'r2', 'r3', 'g5'],
+		], {
+			level: 1,
+			play_stacks: [0, 0, 0, 0, 0],
+			clue_tokens: 8,
+			starting: PLAYER.BOB,
+			variant: {'id': 21, 'name': 'Black (5 Suits)', 'suits': ['Red', 'Yellow', 'Green', 'Blue', 'Black']}
+		});
+
+		[1].forEach(index => state.hands[PLAYER.ALICE][index].clued = true);
+
+		takeTurn(state, 'Bob clues black to Alice (slot 1,5)');
+
+		assert.ok(state.common.thoughts[0].inferred.some(c => c.matches({suitIndex: 4, rank: 2})));
+		assert.ok(state.common.thoughts[0].inferred.some(c => c.matches({suitIndex: 4, rank: 5})));
+	});
+});

--- a/test/playful-sieve/unlock-promise.js
+++ b/test/playful-sieve/unlock-promise.js
@@ -209,7 +209,7 @@ describe('unlock promise', () => {
 			card.clued = true;
 			card.clues.push({ type: CLUE.RANK, value: card.rank });
 			for (const poss of /** @type {const} */ (['inferred', 'possible']))
-				state.common.thoughts[card.order].intersect(poss, state.suits.map((_, suitIndex) => ({ suitIndex, rank: card.rank })));
+				state.common.thoughts[card.order].intersect(poss, state.variant.suits.map((_, suitIndex) => ({ suitIndex, rank: card.rank })));
 		}
 
 		team_elim(state);

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -35,11 +35,11 @@ export const PLAYER = /** @type {const} */ ({
 });
 
 const names = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'];
-const noVar = /** @type {Variant} */ {
+const noVar = /** @type {Variant} */ ({
 	"id": 0,
 	"name": "No Variant",
 	"suits": ["Red", "Yellow", "Green", "Blue", "Purple"]
-};
+});
 
 /**
  * @param {string} short
@@ -73,7 +73,7 @@ function init_state(state, options) {
 		state.discard_stacks[suitIndex][rank - 1]++;
 
 		// Discarded all copies of a card - the new max rank is 1 less than the rank of discarded card
-		if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, state.variant, identity) && state.max_ranks[suitIndex] > rank - 1)
+		if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.variant, identity) && state.max_ranks[suitIndex] > rank - 1)
 			state.max_ranks[suitIndex] = rank - 1;
 	}
 
@@ -217,7 +217,7 @@ export function parseAction(state, rawAction) {
 		case 'clues': {
 			const clue = ('12345'.indexOf(parts[2]) !== -1) ?
 				{ type: CLUE.RANK, value: Number(parts[2]) } :
-				{ type: CLUE.COLOUR, value: state.suits.findIndex(suit => suit.toLowerCase() === parts[2].toLowerCase()) };
+				{ type: CLUE.COLOUR, value: state.variant.suits.findIndex(suit => suit.toLowerCase() === parts[2].toLowerCase()) };
 
 			if (clue.type === CLUE.COLOUR && clue.value === -1)
 				throw new Error(`Unable to parse clue ${parts[2]}`);

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,11 +1,12 @@
 import { CLUE } from '../src/constants.js';
-import { getShortForms, cardCount } from '../src/variants.js';
+import { cardCount } from '../src/variants.js';
 import * as Utils from '../src/tools/util.js';
 import { logAction, logClue } from '../src/tools/log.js';
 
 /**
  * @typedef {import ('../src/basics/State.js').State} State
  * @typedef {import('../src/types.js').Action} Action
+ * @typedef {import('../src/variants.js').Variant} Variant
  * 
  * @typedef SetupOptions
  * @property {number} level
@@ -13,6 +14,7 @@ import { logAction, logClue } from '../src/tools/log.js';
  * @property {string[]} discarded
  * @property {number} clue_tokens
  * @property {number} starting
+ * @property {Variant} variant
  * @property {(state: State) => void} init
  */
 
@@ -33,8 +35,7 @@ export const PLAYER = /** @type {const} */ ({
 });
 
 const names = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'];
-const suits = ['Red', 'Yellow', 'Green', 'Blue', 'Purple'];
-const noVar = {
+const noVar = /** @type {Variant} */ {
 	"id": 0,
 	"name": "No Variant",
 	"suits": ["Red", "Yellow", "Green", "Blue", "Purple"]
@@ -112,10 +113,9 @@ function injectFuncs(options) {
  */
 export function setup(StateClass, hands, options = {}) {
 	const playerNames = names.slice(0, hands.length);
+	const variant = options.variant ?? noVar;
 
-	getShortForms(noVar.suits);
-
-	const state = new StateClass(-1, playerNames, 0, suits, noVar, false, options.level ?? 1);
+	const state = new StateClass(-1, playerNames, 0, variant.suits, variant, false, options.level ?? 1);
 	Utils.globalModify({state});
 
 	let orderCounter = 0;

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -115,7 +115,7 @@ export function setup(StateClass, hands, test_options = {}) {
 	const playerNames = names.slice(0, hands.length);
 	const variant = test_options.variant ?? noVar;
 
-	const state = new StateClass(-1, playerNames, 0, variant.suits, variant, test_options, false, test_options.level ?? 1);
+	const state = new StateClass(-1, playerNames, 0, variant, test_options, false, test_options.level ?? 1);
 	Utils.globalModify({state});
 
 	let orderCounter = 0;

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -34,6 +34,12 @@ export const PLAYER = /** @type {const} */ ({
 
 const names = ['Alice', 'Bob', 'Cathy', 'Donald', 'Emily'];
 const suits = ['Red', 'Yellow', 'Green', 'Blue', 'Purple'];
+const noVar = {
+	"id": 0,
+	"newID": "R+Y+G+B+P",
+	"name": "No Variant",
+	"suits": ["Red", "Yellow", "Green", "Blue", "Purple"]
+};
 
 /**
  * @param {string} short
@@ -67,7 +73,7 @@ function init_state(state, options) {
 		state.discard_stacks[suitIndex][rank - 1]++;
 
 		// Discarded all copies of a card - the new max rank is 1 less than the rank of discarded card
-		if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, identity) && state.max_ranks[suitIndex] > rank - 1) {
+		if (state.discard_stacks[suitIndex][rank - 1] === cardCount(state.suits, state.variant, identity) && state.max_ranks[suitIndex] > rank - 1) {
 			state.max_ranks[suitIndex] = rank - 1;
 		}
 	}
@@ -111,7 +117,7 @@ function injectFuncs(options) {
 export function setup(StateClass, hands, options = {}) {
 	const playerNames = names.slice(0, hands.length);
 
-	const state = new StateClass(-1, playerNames, 0, suits, false, options.level ?? 1);
+	const state = new StateClass(-1, playerNames, 0, suits, noVar, false, options.level ?? 1);
 	Utils.globalModify({state});
 
 	let orderCounter = 0;

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,5 +1,5 @@
 import { CLUE } from '../src/constants.js';
-import { cardCount } from '../src/variants.js';
+import { getShortForms, cardCount } from '../src/variants.js';
 import * as Utils from '../src/tools/util.js';
 import { logAction, logClue } from '../src/tools/log.js';
 
@@ -116,6 +116,8 @@ function injectFuncs(options) {
  */
 export function setup(StateClass, hands, options = {}) {
 	const playerNames = names.slice(0, hands.length);
+
+	getShortForms(noVar.suits);
 
 	const state = new StateClass(-1, playerNames, 0, suits, noVar, false, options.level ?? 1);
 	Utils.globalModify({state});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -239,7 +239,7 @@ export function parseAction(state, rawAction) {
 			}
 
 			if (target !== state.ourPlayerIndex) {
-				const list = state.hands[target].clueTouched(clue, state.suits).map(c => c.order);
+				const list = state.hands[target].clueTouched(clue, state.variant).map(c => c.order);
 				if (list.length === 0) {
 					throw new Error(`Clue ${logClue(Object.assign({}, clue, { target }))} touches no cards.`);
 				}


### PR DESCRIPTION
Note that no conventions are implemented for these variants, and the bots will perform poorly when thrown into some of them.

Adds support for:
- The following special suits and their combinations
![image](https://github.com/WillFlame14/hanabi-bot/assets/86388449/3b67654d-3802-4d91-bf64-c32f82bc95d3)
- Critical 4s
- Suit-Ones and Suit-Fives
- Deceptive-Ones and Deceptive-Fives (Technically. The bots understand cluing, correctly eliminate, and do not give impossible clues, but they do not clue these alternative ranks for the ones/fives.)
- Funnels and Chimneys (Technically.  The bots understand cluing, correctly eliminate, but they are unable to use the funnels/chimneys to their advantage.)