### PR TITLE
URL encode username and password

### DIFF
--- a/src/hanabi-bot.js
+++ b/src/hanabi-bot.js
@@ -18,7 +18,10 @@ function connect(bot_index = '') {
 		throw new Error(`Missing ${u_field} and ${p_field} environment variables.`);
 	}
 
-	const data = `username=${process.env[u_field]}&password=${process.env[p_field]}&version=bot`;
+	const username = encodeURIComponent(process.env[u_field]);
+	const password = encodeURIComponent(process.env[p_field]);
+	const data = `username=${username}&password=${password}&version=bot`;
+
 	const options = {
 		hostname: 'hanab.live',
 		port: 443,


### PR DESCRIPTION
Without this it's not possible to login with certain special characters in the password (or in the username).