### PR TITLE
Fix impossible focus inferrences

### DIFF
--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -143,7 +143,7 @@ export function interpret_clue(game, action) {
 	const { clue, giver, list, target, mistake = false, ignoreStall = false } = action;
 	const { focused_card, chop } = determine_focus(state.hands[target], common, list, { beforeClue: true });
 
-	const focus_thoughts = common.thoughts[focused_card.order];
+	const focus_thoughts = game.players[target].thoughts[focused_card.order];
 	focus_thoughts.focused = true;
 
 	const { fix, layered_reveal } = apply_good_touch(game, action);

--- a/test/h-group/level-5/clandestine-finesses.js
+++ b/test/h-group/level-5/clandestine-finesses.js
@@ -117,4 +117,21 @@ describe('clandestine finesses', () => {
 
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, false);
 	});
+
+	it(`understands a clandestine finesse with card elimination`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y4', 'y5', 'y1', 'y1'],
+			['g3', 'g3', 'b2', 'b1'],
+			['g1', 'r1', 'r3', 'y2']
+		], {
+			level: 5,
+			starting: PLAYER.CATHY
+		});
+
+		takeTurn(game, 'Cathy clues 3 to Alice (slot 4)');
+
+		// Alice's slot 4 should be r3 as a Clandestine Finesse (no 3 is a valid bluff target.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][3].order], ['r3']);
+	});
 });


### PR DESCRIPTION
This fixes #209 by using the player's thoughts about the cards which accounts for the fact that it isn't possible to have a card for which all identities are visible in someone else's hand.