### PR TITLE
Remove self passback opportunity on bluff clues.

### DIFF
--- a/src/conventions/h-group/update-turn.js
+++ b/src/conventions/h-group/update-turn.js
@@ -75,7 +75,7 @@ export function remove_finesse(game, waiting_connection) {
 function resolve_card_retained(game, waiting_connection) {
 	const { common, state, me } = game;
 	const { connections, conn_index, giver, target, inference, action_index, ambiguousPassback, selfPassback } = waiting_connection;
-	const { type, reacting, hidden, ambiguous } = connections[conn_index];
+	const { type, reacting, hidden, ambiguous, bluff } = connections[conn_index];
 	const { order } = connections[conn_index].card;
 
 	// Card may have been updated, so need to find it again
@@ -134,7 +134,8 @@ function resolve_card_retained(game, waiting_connection) {
 		// If we've reached the end of the connections, then the target of the clue is the final reacting player
 		const next_reacting = (next_reacting_index === -1) ? target : connections[next_reacting_index].reacting;
 
-		if (next_reacting === reacting && giver !== state.ourPlayerIndex && !selfPassback) {
+		// We give one round for the target player to recognize a self finesse. Bluffs however must resolve immediately.
+		if (!bluff && next_reacting === reacting && giver !== state.ourPlayerIndex && !selfPassback) {
 			logger.warn(`${state.playerNames[reacting]} didn't play into ${type} but it was a self-component, waiting`);
 			waiting_connection.selfPassback = true;
 			return { remove: false };

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -671,4 +671,33 @@ describe('bluff clues', () => {
 		// Slot 3 should be g2.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2].order], ['g2']);
 	});
+
+	it(`understands a finesse when a player doesn't play into potential bluff`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y1', 'r2', 'b3', 'b1', 'r3'],
+			['g3', 'r1', 'y4', 'p3', 'r1']
+		], {
+			starting: PLAYER.CATHY,
+			level: 11
+		});
+		takeTurn(game, 'Cathy clues 1 to Alice (slots 3,5)');
+		takeTurn(game, 'Alice plays g1 (slot 5)');
+		takeTurn(game, 'Bob clues 3 to Cathy');
+
+		// Initially Alice thinks this is a self bluff, rather than a finesse.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][1].order], ['r1', 'y1', 'g2', 'b1', 'p1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][1].order].finessed, true);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, false);
+
+		takeTurn(game, 'Cathy clues 1 to Bob');
+
+		// After Cathy doesn't play into it, Alice should know it's a finesse.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['g2']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][1].order].finessed, false);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+
+		// This should also remove the original thoughts in Cathy's hand.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][1].order].inferred.length > 5, true);
+	});
 });


### PR DESCRIPTION
Since bluffs must resolve immediately a self passback is not valid. Fixes #219.