### PR TITLE
Resolve bluffs when determining if another player has the matching card.

### DIFF
--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -186,14 +186,14 @@ function find_unknown_connecting(game, giver, target, reacting, identity, firstP
  * @param {number} giver 				The player index that gave the clue. They cannot deduce unknown information about their own hand.
  * @param {number} target 				The player index receiving the clue. They will not find self-prompts or self-finesses.
  * @param {Connection[]} connections	The complete connections leading to the play of a card.
- * @param {ActualCard[]} promised		The non-hidden play(s) which are promised.
+ * @param {ActualCard} focusedCard		The focused card.
  * @param {Identity} focusIdentity		The expected identity of the focus.
  * @returns {Connection[]}
  */
-export function resolve_bluff(game, giver, target, connections, promised, focusIdentity) {
+export function resolve_bluff(game, giver, target, connections, focusedCard, focusIdentity) {
 	if (connections.length == 0 || !connections[0].bluff)
 		return connections;
-
+	const promised = connections.filter(conn => !conn.hidden).map(conn => conn.card).concat([focusedCard]);
 	const { state } = game;
 	const bluffCard = connections[0].card;
 	let bluff_fail_reason = undefined;

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -43,7 +43,6 @@ function find_colour_focus(game, suitIndex, action) {
 
 	let firstPlay = true;
 	let finesses = 0;
-	const promised = [];
 
 	while (next_rank < state.max_ranks[suitIndex]) {
 		const identity = { suitIndex, rank: next_rank };
@@ -75,21 +74,17 @@ function find_colour_focus(game, suitIndex, action) {
 			}
 
 			// Even if a finesse is possible, it might not be a finesse
-			promised.push(focused_card);
-			const possible_connections = resolve_bluff(game, giver, target, connections, promised, { suitIndex, rank: next_rank });
+			const possible_connections = resolve_bluff(game, giver, target, connections, focused_card, { suitIndex, rank: next_rank });
 			if (connections.length == 0 || possible_connections.length > 0)
 				focus_possible.push({ suitIndex, rank: next_rank, save: false, connections: possible_connections, interp: CLUE_INTERP.PLAY });
-			promised.pop();
 		}
 		state.play_stacks[suitIndex]++;
 		next_rank++;
 
-		promised.push(connecting.at(-1).card);
 		connections = connections.concat(connecting);
 		already_connected = already_connected.concat(connecting.map(conn => conn.card.order));
 	}
-	promised.push(focused_card);
-	connections = resolve_bluff(game, giver, target, connections, promised, { suitIndex, rank: next_rank });
+	connections = resolve_bluff(game, giver, target, connections, focused_card, { suitIndex, rank: next_rank });
 	if (connections.length == 0) {
 		// Undo plays invalidated by a false bluff.
 		next_rank = old_play_stacks[suitIndex] + 1;
@@ -192,7 +187,6 @@ function find_rank_focus(game, rank, action) {
 			continue;
 		}
 
-		const promised = [];
 		/** @type {Connection[]} */
 		let connections = [];
 		let finesses = 0;
@@ -242,16 +236,13 @@ function find_rank_focus(game, rank, action) {
 				looksDirect = focus_thoughts.identity() === undefined && looksSave;
 
 				if (rank === next_rank) {
-					promised.push(focused_card);
-					const possible_connections = resolve_bluff(game, giver, target, Utils.objClone(connections), promised, { suitIndex, rank: next_rank });
+					const possible_connections = resolve_bluff(game, giver, target, Utils.objClone(connections), focused_card, { suitIndex, rank: next_rank });
 					// Even if a finesse is possible, it might not be a finesse
 					if (connections.length == 0 || possible_connections.length > 0)
 						focus_possible.push({ suitIndex, rank, save: false, connections: possible_connections, interp: CLUE_INTERP.PLAY });
-					promised.pop();
 				}
 			}
 
-			promised.push(connecting.at(-1).card);
 			connections = connections.concat(connecting);
 			already_connected = already_connected.concat(connecting.map(conn => conn.card.order));
 
@@ -267,8 +258,7 @@ function find_rank_focus(game, rank, action) {
 				i.inference === undefined || i.inference.suitIndex === suitIndex).map(i => i.order);
 			connecting = find_connecting(game, giver, target, { suitIndex, rank: next_rank }, looksDirect, firstPlay, already_connected, ignoreOrders);
 		}
-		promised.push(focused_card);
-		connections = resolve_bluff(game, giver, target, connections, promised, { suitIndex, rank: next_rank });
+		connections = resolve_bluff(game, giver, target, connections, focused_card, { suitIndex, rank: next_rank });
 		if (connections.length == 0) {
 			// Undo plays invalidated by a false bluff.
 			next_rank = old_play_stacks[suitIndex] + 1;

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -56,6 +56,7 @@ function own_prompt(game, finesses, prompt, identity) {
  * @param {Game} game
  * @param {number} giver
  * @param {number} target
+ * @param {ActualCard} focusedCard
  * @param {Identity} identity
  * @param {boolean} looksDirect
  * @param {number[]} connected
@@ -66,12 +67,12 @@ function own_prompt(game, finesses, prompt, identity) {
  * @param {boolean} firstPlay
  * @returns {Connection[]}
  */
-function connect(game, giver, target, identity, looksDirect, connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay) {
+function connect(game, giver, target, focusedCard, identity, looksDirect, connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay) {
 	const { common, state } = game;
 	const our_hand = state.hands[state.ourPlayerIndex];
 
 	// First, see if someone else has the connecting card
-	const other_connecting = find_connecting(game, giver, target, identity, looksDirect, firstPlay, connected, ignoreOrders, { knownOnly: [ignorePlayer] });
+	const other_connecting = resolve_bluff(game, giver, target, find_connecting(game, giver, target, identity, looksDirect, firstPlay, connected, ignoreOrders, { knownOnly: [ignorePlayer] }), focusedCard, identity);
 	if (other_connecting.length > 0 && other_connecting[0].type !== 'terminate' && (other_connecting.at(-1).reacting != state.ourPlayerIndex || other_connecting.at(-1).card.matches(identity, {assume: true})))
 		return other_connecting;
 
@@ -187,19 +188,17 @@ export function find_own_finesses(game, action, { suitIndex, rank }, looksDirect
 	let firstPlay = true;
 	let finesses = 0;
 	let direct = looksDirect;
-	const promised = [];
 
 	for (let next_rank = hypo_state.play_stacks[suitIndex] + 1; next_rank < rank; next_rank++) {
 		const next_identity = { suitIndex, rank: next_rank };
 		const ignoreOrders = game.next_ignore[next_rank - hypo_state.play_stacks[suitIndex] - 1]?.map(i => i.order) ?? [];
 
-		const curr_connections = connect(hypo_game, giver, target, next_identity, direct, already_connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay);
+		const curr_connections = connect(hypo_game, giver, target, focused_card, next_identity, direct, already_connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay);
 		firstPlay = false;
 
 		if (curr_connections.length === 0)
 			throw new IllegalInterpretation(`no connecting cards found for identity ${logCard(next_identity)}`);
 
-		promised.push(curr_connections.at(-1).card);
 		let allHidden = true;
 		for (const connection of curr_connections) {
 			connections.push(connection);
@@ -238,8 +237,7 @@ export function find_own_finesses(game, action, { suitIndex, rank }, looksDirect
 		if (allHidden)
 			next_rank--;
 	}
-	promised.push(focused_card);
-	return resolve_bluff(game, giver, target, connections, promised, { suitIndex, rank });
+	return resolve_bluff(game, giver, target, connections, focused_card, { suitIndex, rank });
 }
 
 /**

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -174,6 +174,20 @@ describe('bluff clues', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][0].order], ['b4']);
 	});
 
+	it(`recognizes a finesse when target is not a valid bluff target`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b3', 'y3', 'g1', 'y1'],
+			['r2', 'b1', 'p5', 'p1'],
+			['p2', 'r1', 'b2', 'y1']
+		], {
+			level: 11,
+			starting: PLAYER.CATHY
+		});
+		takeTurn(game, 'Cathy clues 2 to Donald');
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['p1']);
+	});
+
 	it('infers the identity of indirect bluffs', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],


### PR DESCRIPTION
If another player is bluffed for the card but it is an invalid bluff target then we shouldn't consider this connection. Fixes #219.