### PR TITLE
Detect invalid bluff targets through possible plays from other connections

### DIFF
--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -194,16 +194,18 @@ function find_unknown_connecting(game, giver, target, reacting, identity, looksD
 /**
  * Determines whether a bluff connection is a valid bluff, and updates the connection accordingly.
  * @param {Game} game
+ * @param {number} target
  * @param {Connection[]} connections	The complete connections leading to the play of a card.
  * @param {ActualCard} focusedCard		The focused card.
  * @param {Identity} focusIdentity		The expected identity of the focus.
  * @returns {Connection[]}
  */
-export function resolve_bluff(game, connections, focusedCard, focusIdentity) {
+export function resolve_bluff(game, target, connections, focusedCard, focusIdentity) {
 	if (connections.length == 0 || !connections[0].bluff)
 		return connections;
 
 	const promised = connections.filter(conn => !conn.hidden).map(conn => conn.card).concat([focusedCard]);
+	const promisedPlayer = connections.filter(conn => !conn.hidden).map(conn => conn.reacting).concat([target]);
 	const { state } = game;
 	const bluffCard = connections[0].card;
 	let bluff_fail_reason = undefined;
@@ -219,7 +221,7 @@ export function resolve_bluff(game, connections, focusedCard, focusIdentity) {
 		// A bluff must be recognizable. As such, there should be no connection
 		// between the bluffed card and at least one of the following plays
 		// as known by the player who would play next after the bluff play.
-		const next_player = state.hands.findIndex(hand => hand.findOrder(promised[1].order));
+		const next_player = promisedPlayer[1];
 		const bluff_identities = bluffCard.identity() === undefined ?
 			game.players[state.ourPlayerIndex].thoughts[bluffCard.order].inferred.filter(c => state.isPlayable(c)) :
 			[bluffCard];

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -75,7 +75,7 @@ function find_colour_focus(game, suitIndex, action) {
 			}
 
 			// Even if a finesse is possible, it might not be a finesse
-			const possible_connections = resolve_bluff(game, connections, focused_card, { suitIndex, rank: next_rank });
+			const possible_connections = resolve_bluff(game, target, connections, focused_card, { suitIndex, rank: next_rank });
 			if (connections.length == 0 || possible_connections.length > 0)
 				focus_possible.push({ suitIndex, rank: next_rank, save: false, connections: possible_connections, interp: CLUE_INTERP.PLAY });
 		}
@@ -86,7 +86,7 @@ function find_colour_focus(game, suitIndex, action) {
 		already_connected = already_connected.concat(connecting.map(conn => conn.card.order));
 	}
 
-	connections = resolve_bluff(game, connections, focused_card, { suitIndex, rank: next_rank });
+	connections = resolve_bluff(game, target, connections, focused_card, { suitIndex, rank: next_rank });
 	if (connections.length == 0) {
 		// Undo plays invalidated by a false bluff.
 		next_rank = old_play_stacks[suitIndex] + 1;
@@ -233,7 +233,7 @@ function find_rank_focus(game, rank, action) {
 				looksDirect = focus_thoughts.identity() === undefined && looksSave;
 
 				if (rank === next_rank) {
-					const possible_connections = resolve_bluff(game, connections, focused_card, identity);
+					const possible_connections = resolve_bluff(game, target, connections, focused_card, identity);
 					// Even if a finesse is possible, it might not be a finesse
 					if (connections.length == 0 || possible_connections.length > 0)
 						focus_possible.push({ suitIndex, rank, save: false, connections: possible_connections, interp: CLUE_INTERP.PLAY });
@@ -253,7 +253,7 @@ function find_rank_focus(game, rank, action) {
 			continue;
 		}
 
-		connections = resolve_bluff(game, connections, focused_card, next_identity);
+		connections = resolve_bluff(game, target, connections, focused_card, next_identity);
 
 		if (connections.length == 0)
 			continue;

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -147,6 +147,73 @@ function resolve_clue(game, old_game, action, inf_possibilities, focused_card) {
 }
 
 /**
+ * Finalizes the bluff connections.
+ * @param {Game} game
+ * @param {number} giver
+ * @param {number} target
+ * @param {FocusPossibility[]} connections
+ * @returns {FocusPossibility[]}
+ */
+export function finalize_bluff_connections(game, giver, target, connections) {
+	const { state } = game;
+
+	const bluff_seat = (giver + 1) % state.numPlayers;
+	const no_bluff_connections = connections.some(conn =>
+		conn.connections.length > 0 && (
+			// If there's a visible connection outside of the bluff seat, expect them to play.
+			conn.connections[0].reacting !== bluff_seat && (bluff_seat == state.ourPlayerIndex || target !== state.ourPlayerIndex) ||
+			// If there's a non-bluff non-finesse connection following this play, it could be accidentally played making this an invalid bluff
+			conn.connections[0].reacting == bluff_seat && !conn.connections[0].bluff && (conn.connections.length == 1 || conn.connections[1].reacting !== bluff_seat && conn.connections[1].type != 'finesse')));
+
+	if (no_bluff_connections) {
+		// Convert possible bluff connections to non-bluff connections.
+		logger.info('removing bluffs due to visible non-bluff connection');
+		connections = connections.reduce((acc, conn) => {
+			if (!conn.connections[0]?.bluff)
+				return acc.concat(conn);
+
+			const expected = { suitIndex: conn.suitIndex, rank: conn.rank - conn.connections.filter(c => !c.hidden).length };
+
+			// If not a hidden connection, and we know the bluff card doesn't match, the real card wasn't found.
+			if (!conn.connections[0].hidden && !conn.connections[0].card.matches(expected, { assume: true }))
+				return acc;
+
+			conn.connections[0].bluff = false;
+			return acc.concat(conn);
+		}, []);
+	}
+	else {
+		const bluff_connections = connections.some(connection =>
+			connection.connections.length > 0 && connection.connections[0].bluff);
+
+		let removed = 0;
+		// Filter plays after hidden bluff connection,
+		connections = connections.reduce((acc, conn) => {
+			if (!conn.connections[0]?.bluff || !conn.connections[0].hidden) {
+				// A non-bluff connection is invalid if it requires a self finesse after a potential bluff play.
+				// E.g. if we could be bluffed for a 3 in one suit, we can't assume we have the connecting 2 in another suit.
+				if (bluff_connections && conn.connections[1]?.type == 'finesse' && conn.connections[1]?.self) {
+					removed++;
+					return acc;
+				}
+				return acc.concat(conn);
+			}
+			// Remove everything after the bluff play to the non-hidden play as they won't
+			// play after the bluff play.
+			const next_visible_connection = conn.connections.findIndex(c => !c.bluff && !c.hidden);
+			conn.connections.splice(1, next_visible_connection);
+
+			return acc.concat(conn);
+		}, []);
+
+		if (removed)
+			logger.info(`Removing ${removed} self finesses due to possible bluff interpretation`);
+	}
+
+	return connections;
+}
+
+/**
  * Interprets the given clue. First tries to look for inferred connecting cards, then attempts to find prompts/finesses.
  * @param {Game} game
  * @param {ClueAction} action
@@ -280,7 +347,8 @@ export function interpret_clue(game, action) {
 		}
 	}
 
-	const focus_possible = find_focus_possible(game, action);
+	let focus_possible = find_focus_possible(game, action);
+	focus_possible = finalize_bluff_connections(game, giver, target, focus_possible);
 	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save }) => logCard({suitIndex, rank}) + (save ? ' (save)' : '')));
 
 	const matched_inferences = focus_possible.filter(p => focus_thoughts.inferred.has(p));
@@ -385,55 +453,7 @@ export function interpret_clue(game, action) {
 			}
 		}
 
-		// If there's a visible connection outside of the bluff seat, a bluff is not a valid interpretation.
-		const bluff_seat = (giver + 1) % state.numPlayers;
-		const no_bluff_connections = state.ourPlayerIndex == bluff_seat && all_connections.some(conn =>
-			conn.connections.length > 0 && conn.connections[0].reacting != bluff_seat);
-
-		if (no_bluff_connections) {
-			// Convert possible bluff connections to non-bluff connections.
-			logger.info('removing bluffs due to visible non-bluff connection');
-			all_connections = all_connections.reduce((acc, conn) => {
-				if (!conn.connections[0]?.bluff)
-					return acc.concat(conn);
-
-				const expected = { suitIndex: conn.suitIndex, rank: conn.rank - conn.connections.filter(c => !c.hidden).length };
-
-				// If not a hidden connection, and we know the bluff card doesn't match, the real card wasn't found.
-				if (!conn.connections[0].hidden && !conn.connections[0].card.matches(expected, { assume: true }))
-					return acc;
-
-				conn.connections[0].bluff = false;
-				return acc.concat(conn);
-			}, []);
-		}
-		else {
-			const bluff_connections = all_connections.some(connection =>
-				connection.connections.length > 0 && connection.connections[0].bluff);
-
-			let removed = 0;
-			// Filter plays after hidden bluff connection,
-			all_connections = all_connections.reduce((acc, conn) => {
-				if (!conn.connections[0]?.bluff || !conn.connections[0].hidden) {
-					// A non-bluff connection is invalid if it requires a self finesse after a potential bluff play.
-					// E.g. if we could be bluffed for a 3 in one suit, we can't assume we have the connecting 2 in another suit.
-					if (bluff_connections && conn.connections[1]?.type == 'finesse' && conn.connections[1]?.self) {
-						removed++;
-						return acc;
-					}
-					return acc.concat(conn);
-				}
-				// Remove everything after the bluff play to the non-hidden play as they won't
-				// play after the bluff play.
-				const next_visible_connection = conn.connections.findIndex(c => !c.bluff && !c.hidden);
-				conn.connections.splice(1, next_visible_connection);
-
-				return acc.concat(conn);
-			}, []);
-
-			if (removed)
-				logger.info(`Removing ${removed} self finesses due to possible bluff interpretation`);
-		}
+		all_connections = finalize_bluff_connections(game, giver, target, all_connections);
 
 		// No inference, but a finesse isn't possible
 		if (all_connections.length === 0) {

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -73,7 +73,7 @@ function connect(game, giver, target, focusedCard, identity, looksDirect, connec
 
 	// First, see if someone else has the connecting card
 	const connections = find_connecting(game, giver, target, identity, looksDirect, firstPlay, connected, ignoreOrders, { knownOnly: [ignorePlayer] });
-	const other_connecting = resolve_bluff(game, connections, focusedCard, identity);
+	const other_connecting = resolve_bluff(game, target, connections, focusedCard, identity);
 	if (other_connecting.length > 0 && other_connecting[0].type !== 'terminate' && (other_connecting.at(-1).reacting != state.ourPlayerIndex || other_connecting.at(-1).card.matches(identity, {assume: true})))
 		return other_connecting;
 
@@ -237,7 +237,7 @@ export function find_own_finesses(game, action, { suitIndex, rank }, looksDirect
 		if (allHidden)
 			next_rank--;
 	}
-	return resolve_bluff(game, connections, focused_card, { suitIndex, rank });
+	return resolve_bluff(game, target, connections, focused_card, { suitIndex, rank });
 }
 
 /**

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -423,6 +423,30 @@ describe('bluff clues', () => {
 		assert.equal(bluff_clues.length, 0);
 	});
 
+	it(`doesn't bluff when bluff can't be known by a later player not to play`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r2', 'r1', 'p2', 'r4'],
+			['p3', 'p2', 'g1', 'g4'],
+			['r1', 'r1', 'r4', 'g3']
+		], {
+			level: 11,
+			starting: PLAYER.CATHY
+		});
+		takeTurn(game, 'Cathy clues purple to Bob');
+		takeTurn(game, 'Donald plays r1 (slot 1)', 'r5');
+
+		// Bob knows he has a purple 2.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][2].order], ['p2']);
+
+		const { play_clues } = find_clues(game);
+		// A bluff through the p2 is invalid, because after the r2 plays, Cathy would think she has r3.
+		const bluff_clues = play_clues[2].filter(clue => {
+			return clue.type == CLUE.RANK && clue.target == 2 && clue.value == 3;
+		});
+		assert.equal(bluff_clues.length, 0);
+	});
+
 	it(`doesn't bluff on top of unknown queued cards`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],


### PR DESCRIPTION
When another player may think they have a card that follows the bluff card they cannot know not to play. Bluffs of this sort should not be given. Fixes #265.