### PR TITLE
Allow inferring known bluff connections.

### DIFF
--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -75,7 +75,7 @@ function find_colour_focus(game, suitIndex, action) {
 			}
 
 			// Even if a finesse is possible, it might not be a finesse
-			const possible_connections = resolve_bluff(game, connections, focused_card, { suitIndex, rank: next_rank });
+			const possible_connections = resolve_bluff(game, connections, focused_card, { suitIndex, rank: next_rank }, action);
 			if (connections.length == 0 || possible_connections.length > 0)
 				focus_possible.push({ suitIndex, rank: next_rank, save: false, connections: possible_connections, interp: CLUE_INTERP.PLAY });
 		}
@@ -86,7 +86,7 @@ function find_colour_focus(game, suitIndex, action) {
 		already_connected = already_connected.concat(connecting.map(conn => conn.card.order));
 	}
 
-	connections = resolve_bluff(game, connections, focused_card, { suitIndex, rank: next_rank });
+	connections = resolve_bluff(game, connections, focused_card, { suitIndex, rank: next_rank }, action);
 	if (connections.length == 0) {
 		// Undo plays invalidated by a false bluff.
 		next_rank = old_play_stacks[suitIndex] + 1;
@@ -233,7 +233,7 @@ function find_rank_focus(game, rank, action) {
 				looksDirect = focus_thoughts.identity() === undefined && looksSave;
 
 				if (rank === next_rank) {
-					const possible_connections = resolve_bluff(game, connections, focused_card, identity);
+					const possible_connections = resolve_bluff(game, connections, focused_card, identity, action);
 					// Even if a finesse is possible, it might not be a finesse
 					if (connections.length == 0 || possible_connections.length > 0)
 						focus_possible.push({ suitIndex, rank, save: false, connections: possible_connections, interp: CLUE_INTERP.PLAY });
@@ -253,7 +253,7 @@ function find_rank_focus(game, rank, action) {
 			continue;
 		}
 
-		connections = resolve_bluff(game, connections, focused_card, next_identity);
+		connections = resolve_bluff(game, connections, focused_card, next_identity, action);
 
 		if (connections.length == 0)
 			next_rank = old_play_stacks[suitIndex] + 1;

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -331,7 +331,9 @@ function find_self_finesse(game, giver, identity, connected, ignoreOrders, fines
 		return [{ type: 'finesse', reacting, card: finesse, hidden: true, self: true, identities: [finesse.raw()] }];
 	}
 
-	if (card.inferred.has(identity) && card.matches(identity, { assume: true })) {
+	const bluff = game.level >= LEVEL.BLUFFS && firstPlay && state.ourPlayerIndex == bluff_seat;
+	if (card.inferred.has(identity) && card.matches(identity, { assume: true }) ||
+		bluff && card.inferred.some(id => state.isPlayable(id))) {
 		if (game.level === 1 && connected.length >= 1)
 			throw new IllegalInterpretation(`blocked ${finesses >= 1 ? 'double finesse' : 'prompt + finesse'} at level 1`);
 
@@ -351,8 +353,6 @@ function find_self_finesse(game, giver, identity, connected, ignoreOrders, fines
 
 			return state.hands.flat().find(c => c.order === ignored_order).matches(identity);
 		});
-
-		const bluff = game.level >= LEVEL.BLUFFS && firstPlay && state.ourPlayerIndex == bluff_seat;
 
 		return [{ type: 'finesse', reacting, card: finesse, self: true, bluff, identities: [identity], certain, ambiguous }];
 	}

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -65,15 +65,16 @@ function own_prompt(game, finesses, prompt, identity) {
  * @param {number[]} selfRanks
  * @param {number} finesses
  * @param {boolean} firstPlay
+ * @param {ClueAction} action
  * @returns {Connection[]}
  */
-function connect(game, giver, target, focusedCard, identity, looksDirect, connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay) {
+function connect(game, giver, target, focusedCard, identity, looksDirect, connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay, action) {
 	const { common, state } = game;
 	const our_hand = state.hands[state.ourPlayerIndex];
 
 	// First, see if someone else has the connecting card
 	const connections = find_connecting(game, giver, target, identity, looksDirect, firstPlay, connected, ignoreOrders, { knownOnly: [ignorePlayer] });
-	const other_connecting = resolve_bluff(game, connections, focusedCard, identity);
+	const other_connecting = resolve_bluff(game, connections, focusedCard, identity, action);
 	if (other_connecting.length > 0 && other_connecting[0].type !== 'terminate' && (other_connecting.at(-1).reacting != state.ourPlayerIndex || other_connecting.at(-1).card.matches(identity, {assume: true})))
 		return other_connecting;
 
@@ -193,7 +194,7 @@ export function find_own_finesses(game, action, { suitIndex, rank }, looksDirect
 		const next_identity = { suitIndex, rank: next_rank };
 		const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
 
-		const curr_connections = connect(hypo_game, giver, target, focused_card, next_identity, direct, already_connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay);
+		const curr_connections = connect(hypo_game, giver, target, focused_card, next_identity, direct, already_connected, ignoreOrders, ignorePlayer, selfRanks, finesses, firstPlay, action);
 		firstPlay = false;
 
 		if (curr_connections.length === 0)
@@ -237,7 +238,7 @@ export function find_own_finesses(game, action, { suitIndex, rank }, looksDirect
 		if (allHidden)
 			next_rank--;
 	}
-	return resolve_bluff(game, connections, focused_card, { suitIndex, rank });
+	return resolve_bluff(game, connections, focused_card, { suitIndex, rank }, action);
 }
 
 /**

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -325,14 +325,14 @@ function find_self_finesse(game, giver, identity, connected, ignoreOrders, fines
 	const card = me.thoughts[finesse.order];
 	const reacting = state.ourPlayerIndex;
 
+	const bluff = game.level >= LEVEL.BLUFFS && firstPlay && state.ourPlayerIndex == bluff_seat;
 	if (card.rewinded && finesse.suitIndex !== identity.suitIndex && state.isPlayable(finesse)) {
 		if (game.level < LEVEL.INTERMEDIATE_FINESSES)
 			throw new IllegalInterpretation(`blocked layered finesse at level ${game.level}`);
 
-		return [{ type: 'finesse', reacting, card: finesse, hidden: true, self: true, identities: [finesse.raw()] }];
+		return [{ type: 'finesse', reacting, card: finesse, hidden: true, self: true, bluff, identities: [finesse.raw()] }];
 	}
 
-	const bluff = game.level >= LEVEL.BLUFFS && firstPlay && state.ourPlayerIndex == bluff_seat;
 	if (card.inferred.has(identity) && card.matches(identity, { assume: true }) ||
 		bluff && card.inferred.some(id => state.isPlayable(id))) {
 		if (game.level === 1 && connected.length >= 1)

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -55,6 +55,24 @@ describe('bluff clues', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['p3']);
 	});
 
+	it(`understands a self color bluff`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g5', 'y2', 'b3', 'y5', 'y3'],
+			['p4', 'r3', 'g1', 'y4', 'b3'],
+		], {
+			level: 11,
+			play_stacks: [0, 0, 0, 0, 0],
+			starting: PLAYER.BOB
+		});
+		takeTurn(game, 'Bob clues 2 to Alice (slot 5)');
+		takeTurn(game, 'Cathy clues red to Alice (slot 5)');
+
+		// Cathy's slot 1 could be any playable 1.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['y1', 'g1', 'b1', 'p1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+	});
+
 	it(`understands a self finesse that's too long to be a bluff`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -90,6 +90,26 @@ describe('bluff clues', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['r1', 'y1', 'g1', 'b1', 'p1']);
 	});
 
+	it(`understands a known bluff`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r3', 'y2', 'g2', 'g2', 'b2'],
+			['p4', 'b1', 'b1', 'b1', 'y3'],
+		], {
+			level: { min: 11 },
+			play_stacks: [0, 0, 0, 0, 0],
+			starting: PLAYER.CATHY
+		});
+		takeTurn(game, 'Cathy clues blue to Bob');
+
+		// Despite knowing that it can't be b1, the bluff is still recognized.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['r1', 'y1', 'g1', 'b1', 'p1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+
+		// Alice knows it can't be b1.
+		ExAsserts.cardHasInferences(game.players[PLAYER.ALICE].thoughts[game.state.hands[PLAYER.ALICE][0].order], ['r1', 'y1', 'g1', 'p1']);
+	});
+
 	it('understands giving a direct play through a bluff opportunity', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -55,22 +55,22 @@ describe('bluff clues', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['p3']);
 	});
 
-	it(`understands a self color bluff`, () => {
+	it(`doesn't give a self colour bluff`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['g5', 'y2', 'b3', 'y5', 'y3'],
-			['p4', 'r3', 'g1', 'y4', 'b3'],
+			['r1', 'y2', 'g2', 'p2', 'b2'],
+			['p4', 'r3', 'g1', 'y4', 'y3'],
 		], {
 			level: { min: 11 },
 			play_stacks: [0, 0, 0, 0, 0],
-			starting: PLAYER.BOB
+			starting: PLAYER.CATHY
 		});
-		takeTurn(game, 'Bob clues 2 to Alice (slot 5)');
-		takeTurn(game, 'Cathy clues red to Alice (slot 5)');
+		takeTurn(game, 'Cathy clues 2 to Bob');
 
-		// Cathy's slot 1 could be any playable 1.
-		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['y1', 'g1', 'b1', 'p1']);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+		// Alice should not give a self colour bluff to Bob.
+		const { play_clues } = find_clues(game);
+		assert.ok(!play_clues[PLAYER.BOB].some(clue =>
+			clue.type === CLUE.COLOUR && clue.value === COLOUR.BLUE));
 	});
 
 	it(`understands a self finesse that's too long to be a bluff`, () => {


### PR DESCRIPTION
Previously bluffs were only recognized when the card could match the assumed identity but [special bluffs](https://hanabi.github.io/extras/special-bluffs#self-color-bluffs-1-for-1-form-scb) allows for cases where the card cannot be the promised one. Fixes #274.