### PR TITLE
Avoid bluffs based on assymetric knowledge

### DIFF
--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -219,7 +219,7 @@ export function resolve_bluff(game, target, connections, focusedCard, focusIdent
 	if (!bluff_fail_reason && bluffCard.identity() !== undefined) {
 		const nextCard = {suitIndex: bluffCard.suitIndex, rank: bluffCard.rank + 1};
 		if ((clue.clue.type != CLUE.RANK || clue.clue.value == nextCard.rank) &&
-			game.players[target].thoughts[focusedCard.order].inferred.has(nextCard))
+			game.common.thoughts[focusedCard.order].inferred.has(nextCard))
 			bluff_fail_reason = `blind play ${logCard(bluffCard)} connects to clue and inference on focused card`;
 	}
 

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -480,6 +480,22 @@ describe('bluff clues', () => {
 		assert.equal(bluff_clues.length, 0);
 	});
 
+	it(`doesn't bluff when bluff can't be recognized by all players`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y1', 'b5', 'y2', 'y2', 'y4'],
+			['p2', 'r2', 'b2', 'g4', 'y5'],
+		], {
+			level: { min: 11 }
+		});
+
+		const { play_clues } = find_clues(game);
+		const bluff_clues = play_clues[2].filter(clue => {
+			return clue.type == CLUE.RANK && clue.target == 2 && clue.value == 2;
+		});
+		assert.equal(bluff_clues.length, 0);
+	});
+
 	it(`doesn't bluff when bluff can't be known not to connect to focus`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],


### PR DESCRIPTION
Bluffs should be recognizable by all players, otherwise another player may draw incorrect conclusions based on it. Fixes #301