### PR TITLE
Treat saves past finessed players as still urgent.

### DIFF
--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -33,10 +33,13 @@ export function evaluate_clue(game, action, clue, target, target_card, bad_touch
 	logger.highlight('green', `------- ENTERING HYPO ${logClue(clue)} --------`);
 
 	const hypo_game = game.simulate_clue(action, { enableLogs: true });
+	// This is emulating and undoing the needed side effects of handle_action for a clue action.
+	// It might be simpler to call handle_action on the hypo_game.
 	hypo_game.last_actions = game.last_actions.slice();
 	hypo_game.last_actions[action.giver] = action;
 	hypo_game.handle_action({ type: 'turn', num: hypo_game.state.turn_count, currentPlayerIndex: hypo_game.state.nextPlayerIndex(hypo_game.state.ourPlayerIndex) }, true);
 	hypo_game.last_actions = game.last_actions;
+	hypo_game.state.actionList.pop();
 
 	logger.highlight('green', '------- EXITING HYPO --------');
 

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -35,7 +35,6 @@ export function evaluate_clue(game, action, clue, target, target_card, bad_touch
 	const hypo_game = game.simulate_clue(action, { enableLogs: true });
 	// This is emulating the needed side effects of handle_action for a clue action.
 	// It might be simpler to call handle_action on the hypo_game.
-	hypo_game.last_actions = game.last_actions.slice();
 	hypo_game.last_actions[action.giver] = action;
 	hypo_game.handle_action({ type: 'turn', num: hypo_game.state.turn_count, currentPlayerIndex: hypo_game.state.nextPlayerIndex(hypo_game.state.ourPlayerIndex) }, true);
 

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -33,6 +33,10 @@ export function evaluate_clue(game, action, clue, target, target_card, bad_touch
 	logger.highlight('green', `------- ENTERING HYPO ${logClue(clue)} --------`);
 
 	const hypo_game = game.simulate_clue(action, { enableLogs: true });
+	hypo_game.last_actions = game.last_actions.slice();
+	hypo_game.last_actions[action.giver] = action;
+	hypo_game.handle_action({ type: 'turn', num: hypo_game.state.turn_count, currentPlayerIndex: hypo_game.state.nextPlayerIndex(hypo_game.state.ourPlayerIndex) }, true);
+	hypo_game.last_actions = game.last_actions;
 
 	logger.highlight('green', '------- EXITING HYPO --------');
 
@@ -44,55 +48,66 @@ export function evaluate_clue(game, action, clue, target, target_card, bad_touch
 	/** @type {string} */
 	let reason;
 
-	for (const { order, clued } of state.hands[target]) {
-		const card = hypo_game.common.thoughts[order];
-		const visible_card = state.deck[order];
+	const get_finessed_cards = (game) => {
+		return game.state.hands[action.giver].filter(c => !game.common.thoughts[c.order].clued && game.common.thoughts[c.order].finessed);
+	};
 
-		// The focused card must not have been reset and must match inferences
-		if (order === target_card.order) {
+	const finessed_before_clue = get_finessed_cards(game);
+	const finessed_after_clue = get_finessed_cards(hypo_game);
+	const lost_finesse = finessed_before_clue.filter(c => finessed_after_clue.find(other => other.order == c.order) === undefined);
+	if (lost_finesse.length > 0) {
+		reason = `cards ${lost_finesse.map(c => logCard(state.deck[c.order])).join(', ')} lost finesse`;
+	} else {
+		for (const { order, clued } of state.hands[target]) {
+			const card = hypo_game.common.thoughts[order];
+			const visible_card = state.deck[order];
+
+			// The focused card must not have been reset and must match inferences
+			if (order === target_card.order) {
+				if (card.reset) {
+					reason = `card ${logCard(state.deck[card.order])} ${card.order} lost all inferences and was reset`;
+					break;
+				}
+
+				if (!card.inferred.has(visible_card)) {
+					reason = `card ${logCard(visible_card)} has inferences [${card.inferred.map(logCard).join(',')}]`;
+					break;
+				}
+				continue;
+			}
+
+			const old_card = game.common.thoughts[order];
+
+			const allowable_trash = card.chop_moved ||													// Chop moved (might have become trash)
+				old_card.reset || !state.hasConsistentInferences(old_card) || old_card.inferred.length === 0 ||	// Didn't match inference even before clue
+				(clued && isTrash(state, game.me, visible_card, order, { infer: true })) ||				// Previously-clued duplicate or recently became basic trash
+				bad_touch_cards.some(b => b.order === order) ||											// Bad touched
+				card.possible.every(id => isTrash(hypo_game.state, hypo_game.common, id, order, { infer: true }));		// Known trash
+
+			if (allowable_trash || card.possible.length === 1)
+				continue;
+
+			const id = card.identity({ infer: true });
+
+			// For non-focused cards:
 			if (card.reset) {
 				reason = `card ${logCard(state.deck[card.order])} ${card.order} lost all inferences and was reset`;
 				break;
 			}
 
-			if (!card.inferred.has(visible_card)) {
-				reason = `card ${logCard(visible_card)} has inferences [${card.inferred.map(logCard).join(',')}]`;
+			if (id !== undefined && !visible_card.matches(id)) {
+				reason = `card ${logCard(visible_card)} incorrectly inferred to be ${logCard(id)}`;
 				break;
 			}
-			continue;
-		}
 
-		const old_card = game.common.thoughts[order];
+			const looks_playable = hypo_game.common.unknown_plays.has(order) ||
+				hypo_game.common.hypo_stacks[visible_card.suitIndex] >= visible_card.rank ||
+				card.inferred.every(i => i.rank <= hypo_game.common.hypo_stacks[i.suitIndex] + 1);
 
-		const allowable_trash = card.chop_moved ||													// Chop moved (might have become trash)
-			old_card.reset || !state.hasConsistentInferences(old_card) || old_card.inferred.length === 0 ||	// Didn't match inference even before clue
-			(clued && isTrash(state, game.me, visible_card, order, { infer: true })) ||				// Previously-clued duplicate or recently became basic trash
-			bad_touch_cards.some(b => b.order === order) ||											// Bad touched
-			card.possible.every(id => isTrash(hypo_game.state, hypo_game.common, id, order, { infer: true }));		// Known trash
-
-		if (allowable_trash || card.possible.length === 1)
-			continue;
-
-		const id = card.identity({ infer: true });
-
-		// For non-focused cards:
-		if (card.reset) {
-			reason = `card ${logCard(state.deck[card.order])} ${card.order} lost all inferences and was reset`;
-			break;
-		}
-
-		if (id !== undefined && !visible_card.matches(id)) {
-			reason = `card ${logCard(visible_card)} incorrectly inferred to be ${logCard(id)}`;
-			break;
-		}
-
-		const looks_playable = hypo_game.common.unknown_plays.has(order) ||
-			hypo_game.common.hypo_stacks[visible_card.suitIndex] >= visible_card.rank ||
-			card.inferred.every(i => i.rank <= hypo_game.common.hypo_stacks[i.suitIndex] + 1);
-
-		if (looks_playable && !card.inferred.has(visible_card)) {
-			reason = `card ${logCard(visible_card)} looks incorrectly playable with inferences [${card.inferred.map(logCard).join(',')}]`;
-			break;
+			if (looks_playable && !card.inferred.has(visible_card)) {
+				reason = `card ${logCard(visible_card)} looks incorrectly playable with inferences [${card.inferred.map(logCard).join(',')}]`;
+				break;
+			}
 		}
 	}
 

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -33,13 +33,11 @@ export function evaluate_clue(game, action, clue, target, target_card, bad_touch
 	logger.highlight('green', `------- ENTERING HYPO ${logClue(clue)} --------`);
 
 	const hypo_game = game.simulate_clue(action, { enableLogs: true });
-	// This is emulating and undoing the needed side effects of handle_action for a clue action.
+	// This is emulating the needed side effects of handle_action for a clue action.
 	// It might be simpler to call handle_action on the hypo_game.
 	hypo_game.last_actions = game.last_actions.slice();
 	hypo_game.last_actions[action.giver] = action;
 	hypo_game.handle_action({ type: 'turn', num: hypo_game.state.turn_count, currentPlayerIndex: hypo_game.state.nextPlayerIndex(hypo_game.state.ourPlayerIndex) }, true);
-	hypo_game.last_actions = game.last_actions;
-	hypo_game.state.actionList.pop();
 
 	logger.highlight('green', '------- EXITING HYPO --------');
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -257,14 +257,22 @@ export function interpret_clue(game, action) {
 			const hypo_state = hypo_game.state;
 			let played = new IdentitySet(state.variant.suits.length);
 
-			const get_finessed_card = (index) => hypo_state.hands[index].find(c => {
-				const card = hypo_game.common.thoughts[c.order];
+			const get_finessed_card = (index) => {
+				let result = undefined;
+				for (const c of hypo_state.hands[index]) {
+					const card = hypo_game.common.thoughts[c.order];
 
-				if (!card.finessed || card.inferred.some(id => !played.has(id) && !hypo_state.isPlayable(id)))
-					return false;
+					if (!card.finessed || card.inferred.some(id => !played.has(id) && !hypo_state.isPlayable(id)))
+						continue;
 
-				return true;
-			});
+					// Find the finessed card with the lowest finesse_index.
+					if (result !== undefined && card.finesse_index > result.finesse_index)
+						continue;
+
+					result = card;
+				}
+				return result;
+			};
 
 			// If there is at least one player without a finessed play between the giver and target, the save was not urgent.
 			let urgent = true;

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -258,19 +258,17 @@ export function interpret_clue(game, action) {
 			let played = new IdentitySet(state.variant.suits.length);
 
 			const get_finessed_card = (index) => {
+				// Find the finessed card with the lowest finesse_index.
 				let result = undefined;
 				for (const c of hypo_state.hands[index]) {
 					const card = hypo_game.common.thoughts[c.order];
-
-					if (!card.finessed || card.inferred.some(id => !played.has(id) && !hypo_state.isPlayable(id)))
+					if (!card.finessed || result !== undefined && card.finesse_index > result.finesse_index)
 						continue;
-
-					// Find the finessed card with the lowest finesse_index.
-					if (result !== undefined && card.finesse_index > result.finesse_index)
-						continue;
-
 					result = card;
 				}
+				// Only return the card if it is thought to currently be playable.
+				if (!result || result.inferred.some(id => !played.has(id) && !hypo_state.isPlayable(id)))
+					return undefined;
 				return result;
 			};
 

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -265,7 +265,7 @@ export function find_urgent_actions(game, play_clues, save_clues, fix_clues, sta
 
 			// Give them a fix clue with known trash if possible (TODO: Re-examine if this should only be urgent fixes)
 			const trash_fixes = fix_clues[target].filter(clue => clue.trash);
-			if (trash_fixes.length > 0) {
+			if (!finessed_card && trash_fixes.length > 0) {
 				const trash_fix = Utils.maxOn(trash_fixes, ({ result }) => find_clue_value(result));
 				urgent_actions[PRIORITY.TRASH_FIX + nextPriority].push(Utils.clueToAction(trash_fix, tableID));
 				continue;

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -216,21 +216,21 @@ export function find_urgent_actions(game, play_clues, save_clues, fix_clues, sta
 		const nextPriority = high_priority ? 0 : prioritySize;
 
 		// They are locked, we should try to unlock
-		if (!finessed_card && common.thinksLocked(state, target)) {
+		if (common.thinksLocked(state, target)) {
 			const unlock_order = find_unlock(game, target);
-			if (unlock_order !== undefined) {
+			if (unlock_order !== undefined && (!finessed_card || finessed_card.order == unlock_order)) {
 				urgent_actions[PRIORITY.UNLOCK + nextPriority].push({ tableID, type: ACTION.PLAY, target: unlock_order });
 				continue;
 			}
 
 			const play_over_save = find_play_over_save(game, target, play_clues.flat());
-			if (play_over_save !== undefined) {
+			if (!finessed_card && play_over_save !== undefined) {
 				urgent_actions[PRIORITY.PLAY_OVER_SAVE + nextPriority].push(play_over_save);
 				continue;
 			}
 
 			const trash_fixes = fix_clues[target].filter(clue => clue.trash);
-			if (trash_fixes.length > 0) {
+			if (!finessed_card && trash_fixes.length > 0) {
 				const trash_fix = Utils.maxOn(trash_fixes, ({ result }) => find_clue_value(result));
 				urgent_actions[PRIORITY.TRASH_FIX + nextPriority].push(Utils.clueToAction(trash_fix, tableID));
 				continue;

--- a/test/extra-asserts.js
+++ b/test/extra-asserts.js
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { inspect } from 'node:util';
 import { expandShortCard } from './test-utils.js';
 import * as Utils from '../src/tools/util.js';
 import { logCard } from '../src/tools/log.js';
@@ -38,7 +39,7 @@ export function cardHasPossibilities(card, possibilities, message) {
  * @param  {string | Error} 		 [message]		The error message if the assertion fails.
  */
 export function objHasProperties(obj, properties, message) {
-	assert.ok(typeof obj === 'object', `Object (${JSON.stringify(obj)}) is not of type 'object'.`);
+	assert.ok(typeof obj === 'object', `Object (${inspect(obj)}) is not of type 'object'.`);
 	assert.ok(typeof properties === 'object', `Properties (${JSON.stringify(properties)} is not of type 'object'.`);
 
 	assert.deepEqual(Utils.objPick(obj, Object.keys(properties)), properties, message);

--- a/test/h-group/level-4.js
+++ b/test/h-group/level-4.js
@@ -107,7 +107,7 @@ describe('trash chop move', () => {
 
 		const { play_clues, save_clues, fix_clues, stall_clues } = find_clues(game);
 		const playable_priorities = determine_playable_card(game, game.me.thinksPlayables(game.state, PLAYER.ALICE));
-		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities);
+		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities, undefined);
 
 		assert.deepEqual(urgent_actions[PRIORITY.ONLY_SAVE], []);
 		ExAsserts.objHasProperties(urgent_actions[PRIORITY.PLAY_OVER_SAVE][0], { type: ACTION.COLOUR, value: 1 });

--- a/test/h-group/level-5.js
+++ b/test/h-group/level-5.js
@@ -270,7 +270,7 @@ describe('guide principle', () => {
 			['p1', 'p2', 'p3', 'g3'],
 			['p4', 'y5', 'b3', 'p5'],
 			['b4', 'y2', 'p4', 'r4']
-		], { level: { min: 5, max: 10 }, starting: PLAYER.CATHY, play_stacks: [0, 0, 0, 0, 0] });
+		], { level: { min: 5 }, starting: PLAYER.CATHY, play_stacks: [0, 0, 0, 0, 0] });
 		takeTurn(game, 'Cathy clues purple to Donald'); // finesses p1, p2, p3
 		takeTurn(game, 'Donald clues blue to Cathy'); // finesses b1, b2 in our hand
 		takeTurn(game, 'Alice clues 5 to Cathy');
@@ -278,6 +278,24 @@ describe('guide principle', () => {
 		// Understands that Alice may have been deferring the finesse to save the 5 and allow Bob to play.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['b1']);
+	});
+
+	it(`understands a critical save where other players only have a play if we play`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b1', 'p2', 'g4', 'g2'],
+			['y4', 'y5', 'p3', 'b5'],
+			['b4', 'y2', 'p4', 'r4']
+		], { level: { min: 5 }, starting: PLAYER.DONALD, play_stacks: [0, 0, 0, 0, 0] });
+		takeTurn(game, 'Donald clues purple to Cathy'); // finesses p1 (Alice), b1 (Bob), p2 (Bob)
+
+		// Bob may think playing gives Cathy a play, but Alice can see that it doesn't,
+		// and should save Cathy's 5.
+		takeTurn(game, 'Alice clues 5 to Cathy');
+
+		// Understands that Alice may have been deferring the finesse to save the 5 and allow Bob to play.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['p1']);
 	});
 });
 

--- a/test/h-group/level-5.js
+++ b/test/h-group/level-5.js
@@ -283,19 +283,38 @@ describe('guide principle', () => {
 	it(`understands a critical save where other players only have a play if we play`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],
-			['b1', 'p2', 'g4', 'g2'],
-			['y4', 'y5', 'p3', 'b5'],
+			['b1', 'p2', 'g4', 'g3'],
+			['y5', 'p3', 'b5', 'r4'],
 			['b4', 'y2', 'p4', 'r4']
-		], { level: { min: 5 }, starting: PLAYER.DONALD, play_stacks: [0, 0, 0, 0, 0] });
+		], { level: { min: 5 }, starting: PLAYER.CATHY, play_stacks: [0, 0, 0, 0, 0] });
+		// End early game.
+		// TODO: The 5 save should still be urgent without ending the early game in case Cathy has nothing else to do.
+		takeTurn(game, 'Cathy discards r4', 'y4');
 		takeTurn(game, 'Donald clues purple to Cathy'); // finesses p1 (Alice), b1 (Bob), p2 (Bob)
 
 		// Bob may think playing gives Cathy a play, but Alice can see that it doesn't,
 		// and should save Cathy's 5.
+		const action = take_action(game);
+		ExAsserts.objHasProperties(action, { type: ACTION.RANK, target: 2, value: 5 });
 		takeTurn(game, 'Alice clues 5 to Cathy');
 
 		// Understands that Alice may have been deferring the finesse to save the 5 and allow Bob to play.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['p1']);
+	});
+
+	it(`plays rather than saves if it believes a save will become playable`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['p2', 'b4', 'g4', 'g3'],
+			['y4', 'y5', 'p3', 'b5'],
+			['b4', 'y2', 'p4', 'r4']
+		], { level: { min: 5 }, starting: PLAYER.DONALD, play_stacks: [0, 0, 0, 0, 0] });
+		takeTurn(game, 'Donald clues purple to Cathy'); // finesses p1 (Alice), b1 (Bob), p2 (Bob)
+
+		// Bob plays rather than saving Cathy's b5 since the play should make the p3 playable.
+		const action = take_action(game);
+		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][0].order });
 	});
 });
 

--- a/test/h-group/level-5.js
+++ b/test/h-group/level-5.js
@@ -263,6 +263,22 @@ describe('guide principle', () => {
 		const action = take_action(game);
 		ExAsserts.objHasProperties(action, { type: ACTION.RANK, target: 1, value: 5 });
 	});
+
+	it(`understands a critical save while finessed when other potential givers are finessed`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['p1', 'p2', 'p3', 'g3'],
+			['p4', 'y5', 'b3', 'p5'],
+			['b4', 'y2', 'p4', 'r4']
+		], { level: { min: 5, max: 10 }, starting: PLAYER.CATHY, play_stacks: [0, 0, 0, 0, 0] });
+		takeTurn(game, 'Cathy clues purple to Donald'); // finesses p1, p2, p3
+		takeTurn(game, 'Donald clues blue to Cathy'); // finesses b1, b2 in our hand
+		takeTurn(game, 'Alice clues 5 to Cathy');
+
+		// Understands that Alice may have been deferring the finesse to save the 5 and allow Bob to play.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['b1']);
+	});
 });
 
 describe('mistake recovery', () => {


### PR DESCRIPTION
This allows saving critical cards while allowing following players to play into their finesses. Fixes #273.