### PR TITLE
Avoid bluffing out cards that could duplicate our own.

### DIFF
--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -178,6 +178,12 @@ function find_unknown_connecting(game, giver, target, reacting, identity, looksD
 					return card.finessed && card.possible.has(identity);
 				});
 
+			// Don't bluff out cards that could create bad touch in our own hand.
+			if (bluff && giver === state.ourPlayerIndex && state.hands[giver].some(c => c.clued && game.players[giver].thoughts[c.order].inferred.has(finesse))) {
+				logger.warn(`disallowed bluff on ${logCard(finesse)} ${finesse.order}, could be duplicated in giver's hand`);
+				return;
+			}
+
 			// Could be duplicated in giver's hand - disallow hidden finesse unless it could be a bluff.
 			if (!bluff && giver === state.ourPlayerIndex && state.hands[giver].some(c => c.clued && game.players[giver].thoughts[c.order].inferred.has(identity))) {
 				logger.warn(`disallowed hidden finesse on ${logCard(finesse)} ${finesse.order}, true ${logCard(identity)} could be duplicated in giver's hand`);

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -197,9 +197,9 @@ function find_unknown_connecting(game, giver, target, reacting, identity, looksD
 					return card.finessed && card.possible.has(identity);
 				});
 
-			// Don't bluff out cards that could create bad touch in our own hand.
-			if (bluff && giver === state.ourPlayerIndex && state.hands[giver].some(c => c.clued && game.players[giver].thoughts[c.order].inferred.has(finesse))) {
-				logger.warn(`disallowed bluff on ${logCard(finesse)} ${finesse.order}, could be duplicated in giver's hand`);
+			// Don't bluff out cards that are likely to create bad touch in our own hand.
+			if (bluff && giver === state.ourPlayerIndex && state.hands[giver].some(c => c.clued && game.players[giver].thoughts[c.order].inferred.length <= 2 && game.players[giver].thoughts[c.order].inferred.has(finesse))) {
+				logger.warn(`disallowed bluff on ${logCard(finesse)} ${finesse.order}, likely duplicated in giver's hand`);
 				return;
 			}
 

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -541,16 +541,20 @@ describe('bluff clues', () => {
 		assert.equal(bluff_clues.length, 0);
 	});
 
-	it(`doesn't bluff when bluff out a card that it may have clued in hand`, () => {
+	it(`doesn't bluff when bluff out a card that it is likely to have clued in hand`, () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['y1', 'b5', 'y1', 'r4', 'y4'],
-			['p2', 'r4', 'b2', 'g4', 'y4'],
+			['xx', 'xx', 'xx', 'xx'],
+			['y2', 'b5', 'y1', 'r4'],
+			['p2', 'r4', 'b4', 'g4'],
+			['g2', 'r1', 'y1', 'g4'],
 		], {
 			level: { min: 11 },
-			starting: PLAYER.CATHY
+			starting: PLAYER.BOB,
+			play_stacks: [0, 0, 2, 2, 2]
 		});
-		takeTurn(game, 'Cathy clues 1 to Alice (slot 4)');
+		takeTurn(game, 'Bob clues 2 to Alice (slot 4)'); // r2 or y2
+		takeTurn(game, 'Cathy clues 1 to Donald');
+		takeTurn(game, 'Donald plays y1', 'p1');
 		const { play_clues } = find_clues(game);
 		const bluff_clues = play_clues[2].filter(clue => {
 			return clue.type == CLUE.COLOUR && clue.target == 2 && clue.value == COLOUR.BLUE;

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -562,6 +562,27 @@ describe('bluff clues', () => {
 		assert.equal(bluff_clues.length, 0);
 	});
 
+	it(`doesn't assume it can give a layered finess when bluff target is likely a duplicate`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y2', 'b3', 'y1', 'r4'],
+			['p2', 'r4', 'b4', 'g4'],
+			['g2', 'r1', 'y1', 'g4'],
+		], {
+			level: { min: 11 },
+			starting: PLAYER.BOB,
+			play_stacks: [0, 0, 2, 2, 2]
+		});
+		takeTurn(game, 'Bob clues 2 to Alice (slot 4)'); // r2 or y2
+		takeTurn(game, 'Cathy clues 1 to Donald');
+		takeTurn(game, 'Donald plays y1', 'p1');
+		const { play_clues } = find_clues(game);
+		const finesse = play_clues[2].filter(clue => {
+			return clue.type == CLUE.COLOUR && clue.target == 2 && clue.value == COLOUR.BLUE;
+		});
+		assert.equal(finesse.length, 0);
+	});
+
 	it(`understands a bluff on top of known queued plays`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -541,6 +541,23 @@ describe('bluff clues', () => {
 		assert.equal(bluff_clues.length, 0);
 	});
 
+	it(`doesn't bluff when bluff out a card that it may have clued in hand`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y1', 'b5', 'y1', 'r4', 'y4'],
+			['p2', 'r4', 'b2', 'g4', 'y4'],
+		], {
+			level: { min: 11 },
+			starting: PLAYER.CATHY
+		});
+		takeTurn(game, 'Cathy clues 1 to Alice (slot 4)');
+		const { play_clues } = find_clues(game);
+		const bluff_clues = play_clues[2].filter(clue => {
+			return clue.type == CLUE.COLOUR && clue.target == 2 && clue.value == COLOUR.BLUE;
+		});
+		assert.equal(bluff_clues.length, 0);
+	});
+
 	it(`understands a bluff on top of known queued plays`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],


### PR DESCRIPTION
Fixes #308. We don't assume that other players will necessarily avoid potential bad touch bluffs.