### PR TITLE
Simple double discard avoidance

### DIFF
--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -34,7 +34,8 @@ export function handle_action(action, catchup = false) {
 			this.interpret_clue(this, action);
 			this.last_actions[giver] = action;
 
-			state.dda = state.screamed_at = false;
+			state.dda = undefined;
+			state.screamed_at = false;
 
 			// Remove the newly_clued flag
 			for (const order of list) {
@@ -59,7 +60,8 @@ export function handle_action(action, catchup = false) {
 			logger.highlight('yellowb', `Turn ${state.turn_count}: ${logAction(action)}`);
 
 			// Assume one cannot SDCM after being screamed at
-			state.dda = state.screamed_at = false;
+			state.dda = undefined;
+			state.screamed_at = false;
 
 			this.interpret_discard(this, action, card);
 			this.last_actions[playerIndex] = Object.assign(action, { card });
@@ -134,7 +136,8 @@ export function handle_action(action, catchup = false) {
 
 			this.interpret_play(this, action);
 			this.last_actions[playerIndex] = Object.assign(action, { card });
-			state.dda = state.screamed_at = false;
+			state.dda = undefined;
+			state.screamed_at = false;
 			break;
 		}
 		case 'identify': {

--- a/src/action-handler.js
+++ b/src/action-handler.js
@@ -34,7 +34,7 @@ export function handle_action(action, catchup = false) {
 			this.interpret_clue(this, action);
 			this.last_actions[giver] = action;
 
-			state.screamed_at = false;
+			state.dda = state.screamed_at = false;
 
 			// Remove the newly_clued flag
 			for (const order of list) {
@@ -59,7 +59,7 @@ export function handle_action(action, catchup = false) {
 			logger.highlight('yellowb', `Turn ${state.turn_count}: ${logAction(action)}`);
 
 			// Assume one cannot SDCM after being screamed at
-			state.screamed_at = false;
+			state.dda = state.screamed_at = false;
 
 			this.interpret_discard(this, action, card);
 			this.last_actions[playerIndex] = Object.assign(action, { card });
@@ -134,7 +134,7 @@ export function handle_action(action, catchup = false) {
 
 			this.interpret_play(this, action);
 			this.last_actions[playerIndex] = Object.assign(action, { card });
-			state.screamed_at = false;
+			state.dda = state.screamed_at = false;
 			break;
 		}
 		case 'identify': {

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -26,7 +26,7 @@ export class State {
 	strikes = 0;
 	early_game = true;
 	screamed_at = false;
-	dda = false;
+	dda = undefined;
 
 	hands = /** @type {Hand[]} */ ([]);
 	deck = /** @type {ActualCard[]} */ ([]);

--- a/src/basics/State.js
+++ b/src/basics/State.js
@@ -26,6 +26,7 @@ export class State {
 	strikes = 0;
 	early_game = true;
 	screamed_at = false;
+	dda = false;
 
 	hands = /** @type {Hand[]} */ ([]);
 	deck = /** @type {ActualCard[]} */ ([]);
@@ -138,7 +139,7 @@ export class State {
 		const newState = new State(this.playerNames, this.ourPlayerIndex, this.variant, this.options);
 
 		const minimalProps = ['play_stacks', 'hypo_stacks', 'discard_stacks', 'max_ranks', 'hands', 'turn_count', 'clue_tokens',
-			'strikes', 'early_game', 'cardsLeft', 'cardOrder', 'actionList', 'deck', 'screamed_at', 'endgameTurns'];
+			'strikes', 'early_game', 'cardsLeft', 'cardOrder', 'actionList', 'deck', 'screamed_at', 'dda', 'endgameTurns'];
 
 		for (const property of minimalProps)
 			newState[property] = Utils.objClone(this[property]);

--- a/src/conventions/h-group.js
+++ b/src/conventions/h-group.js
@@ -83,7 +83,7 @@ export default class HGroup extends Game {
 			throw new Error('Maximum recursive depth reached.');
 
 		const minimalProps = ['players', 'common', 'last_actions', 'rewindDepth', 'next_ignore', 'next_finesse', 'handHistory',
-			'screamed_at', 'moveHistory', 'finesses_while_finessed', 'stalled_5'];
+			'screamed_at', 'dda', 'moveHistory', 'finesses_while_finessed', 'stalled_5'];
 
 		for (const property of minimalProps)
 			newGame[property] = Utils.objClone(this[property]);

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -60,7 +60,7 @@ export function stall_severity(state, player, giver) {
 	if (player.thinksLocked(state, giver))
 		return 3;
 
-	if (state.screamed_at)
+	if (state.screamed_at || (state.dda && !player.thinksLoaded(state, giver, { assume: false })))
 		return 2;
 
 	if (state.early_game)

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -52,7 +52,6 @@ export function determine_focus(hand, player, list, options = {}) {
  * @param {State} state
  * @param {Player} player
  * @param {number} giver
- * @param {boolean} asymmetric
  */
 export function stall_severity(state, player, giver) {
 	if (state.clue_tokens === 8 && state.turn_count !== 1)

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -60,7 +60,8 @@ export function stall_severity(state, player, giver) {
 	if (player.thinksLocked(state, giver))
 		return 3;
 
-	if (state.screamed_at || (state.dda !== undefined && !player.thinksLoaded(state, giver, { assume: false }) && player.thoughts[player.chop(state.hands[giver]).order].inferred.has(state.dda)))
+	const chop = player.chop(state.hands[giver]);
+	if (state.screamed_at || (state.dda !== undefined && !player.thinksLoaded(state, giver, { assume: false }) && chop !== undefined && player.thoughts[chop.order].possible.has(state.dda)))
 		return 2;
 
 	if (state.early_game)

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -52,6 +52,7 @@ export function determine_focus(hand, player, list, options = {}) {
  * @param {State} state
  * @param {Player} player
  * @param {number} giver
+ * @param {boolean} asymmetric
  */
 export function stall_severity(state, player, giver) {
 	if (state.clue_tokens === 8 && state.turn_count !== 1)
@@ -60,7 +61,7 @@ export function stall_severity(state, player, giver) {
 	if (player.thinksLocked(state, giver))
 		return 3;
 
-	if (state.screamed_at || (state.dda && !player.thinksLoaded(state, giver, { assume: false })))
+	if (state.screamed_at || (state.dda !== undefined && !player.thinksLoaded(state, giver, { assume: false }) && player.thoughts[player.chop(state.hands[giver]).order].inferred.has(state.dda)))
 		return 2;
 
 	if (state.early_game)

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -108,13 +108,14 @@ export function interpret_discard(game, action, card) {
 				undo_hypo_stacks(game, identity);
 			else
 				interpret_sarcastic(game, action);
-		} else if (game.level >= LEVEL.STALLING) {
+		}
+		if (game.level >= LEVEL.STALLING) {
 			// If there is only one of this card left and it could be in the next player's chop,
 			// they are to be treated as in double discard avoidance.
 			const remaining = cardCount(state.variant, { suitIndex, rank }) - state.discard_stacks[suitIndex][rank - 1];
 			const nextPlayerIndex = (playerIndex + 1) % state.numPlayers;
 			const chop = common.chop(state.hands[nextPlayerIndex]);
-			if (remaining == 1 && chop !== undefined && common.thoughts[chop.order].inferred.has(card.identity()))
+			if (remaining == 1 && chop !== undefined && common.thoughts[chop.order].possible.has(card.identity()))
 				state.dda = card.identity();
 		}
 	}

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -114,9 +114,8 @@ export function interpret_discard(game, action, card) {
 			const remaining = cardCount(state.variant, { suitIndex, rank }) - state.discard_stacks[suitIndex][rank - 1];
 			const nextPlayerIndex = (playerIndex + 1) % state.numPlayers;
 			const chop = common.chop(state.hands[nextPlayerIndex]);
-			if (remaining == 1 && chop !== undefined && common.thoughts[chop.order].inferred.has(card)) {
+			if (remaining == 1 && chop !== undefined && common.thoughts[chop.order].inferred.has(card))
 				state.dda = true;
-			}
 		}
 	}
 

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -99,6 +99,7 @@ export function interpret_discard(game, action, card) {
 	// Note: we aren't including chop moved and finessed cards here since those can be asymmetric.
 	// Discarding with a finesse will trigger the waiting connection to resolve.
 	if (rank > state.play_stacks[suitIndex] && rank <= state.max_ranks[suitIndex]) {
+		let sarcastic_targets;
 		if (card.clued) {
 			logger.warn('discarded useful clued card!');
 			common.restore_elim(card);
@@ -107,9 +108,9 @@ export function interpret_discard(game, action, card) {
 			if (failed)
 				undo_hypo_stacks(game, identity);
 			else
-				interpret_sarcastic(game, action);
+				sarcastic_targets = interpret_sarcastic(game, action);
 		}
-		if (game.level >= LEVEL.STALLING) {
+		if (!(sarcastic_targets?.length > 0) && game.level >= LEVEL.STALLING) {
 			// If there is only one of this card left and it could be in the next player's chop,
 			// they are to be treated as in double discard avoidance.
 			const remaining = cardCount(state.variant, { suitIndex, rank }) - state.discard_stacks[suitIndex][rank - 1];

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -114,8 +114,8 @@ export function interpret_discard(game, action, card) {
 			const remaining = cardCount(state.variant, { suitIndex, rank }) - state.discard_stacks[suitIndex][rank - 1];
 			const nextPlayerIndex = (playerIndex + 1) % state.numPlayers;
 			const chop = common.chop(state.hands[nextPlayerIndex]);
-			if (remaining == 1 && chop !== undefined && common.thoughts[chop.order].inferred.has(card))
-				state.dda = true;
+			if (remaining == 1 && chop !== undefined && common.thoughts[chop.order].inferred.has(card.identity()))
+				state.dda = card.identity();
 		}
 	}
 

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -407,11 +407,12 @@ export function take_action(game) {
 	if (state.clue_tokens > 0 && urgent_actions[actionPrioritySize * 2].length > 0)
 		return urgent_actions[actionPrioritySize * 2][0];
 
-	const severity = stall_severity(state, common, state.ourPlayerIndex);
+	const common_severity = stall_severity(state, common, state.ourPlayerIndex);
+	const actual_severity = stall_severity(state, game.players[state.ourPlayerIndex], state.ourPlayerIndex);
 
 	// Stalling situations
-	if (state.clue_tokens > 0 && severity > 0) {
-		const validStall = best_stall_clue(stall_clues, severity);
+	if (state.clue_tokens > 0 && actual_severity > 0) {
+		const validStall = best_stall_clue(stall_clues, common_severity);
 
 		// 8 clues, must stall
 		if (state.clue_tokens === 8) {
@@ -422,7 +423,7 @@ export function take_action(game) {
 		if (validStall)
 			return Utils.clueToAction(validStall, tableID);
 
-		logger.info('no valid stall! severity', severity);
+		logger.info('no valid stall! severity', common_severity);
 	}
 
 	return take_discard(game, state.ourPlayerIndex, trash_cards);

--- a/src/conventions/h-group/take-action.js
+++ b/src/conventions/h-group/take-action.js
@@ -401,7 +401,7 @@ export function take_action(game) {
 		return urgent_actions[actionPrioritySize * 2][0];
 
 	const common_severity = stall_severity(state, common, state.ourPlayerIndex);
-	const actual_severity = stall_severity(state, game.players[state.ourPlayerIndex], state.ourPlayerIndex);
+	const actual_severity = stall_severity(state, game.me, state.ourPlayerIndex);
 
 	// Stalling situations
 	if (state.clue_tokens > 0 && actual_severity > 0) {

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -1,0 +1,39 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { COLOUR, PLAYER, VARIANTS, expandShortCard, setup, takeTurn } from '../test-utils.js';
+import * as ExAsserts from '../extra-asserts.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { ACTION, CLUE } from '../../src/constants.js';
+import logger from '../../src/tools/logger.js';
+import { take_action } from '../../src/conventions/h-group/take-action.js';
+import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+describe('double discard avoidance', () => {
+	it(`understands a clue from a player on double discard avoidance may be a stall`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y2', 'y5', 'b2', 'g4'],
+			['b1', 'b5', 'b4', 'b2'],
+			['y4', 'y2', 'r4', 'r3']
+		], {
+			level: { min: 9 },
+			play_stacks: [2, 2, 2, 2, 2],
+			starting: PLAYER.DONALD
+		});
+		const { state } = game;
+		takeTurn(game, 'Donald discards r3', 'p3'); // Ends early game
+
+		// A discard of a useful card means Alice is in a DDA situation.
+		assert.equal(game.state.dda, true);
+
+		takeTurn(game, 'Alice clues 5 to Bob');
+
+		// No one should be finessed by this as Alice was simply stalling.
+		const finessed = state.hands.map((hand, idx) => idx).filter(idx => state.hands[idx].some(c => game.common.thoughts[c.order].finessed));
+		assert.equal(game.common.waiting_connections.length, 0);
+	});
+
+});

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -73,7 +73,7 @@ describe('double discard avoidance', () => {
 		});
 		const { state } = game;
 		takeTurn(game, 'Bob clues 1 to Cathy');
-		takeTurn(game, 'Cathy clues blue to Donald')
+		takeTurn(game, 'Cathy clues blue to Donald');
 		takeTurn(game, 'Donald discards b1', 'p3'); // Ends early game
 
 		// The sarcastic discard doesn't trigger dda.

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -51,10 +51,10 @@ describe('double discard avoidance', () => {
 		takeTurn(game, 'Donald discards r3', 'p3'); // Ends early game
 
 		// A discard of a useful card means common knowledge is Alice is in a DDA situation.
-		ExAsserts.objHasProperties(game.state.dda, {suitIndex: COLOUR.RED, rank: 3});
+		ExAsserts.objHasProperties(state.dda, {suitIndex: COLOUR.RED, rank: 3});
 
 		// However, since Alice can see the other r3, Alice can discard.
 		const action = take_action(game);
-		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: game.state.hands[PLAYER.ALICE][3].order });
+		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: state.hands[PLAYER.ALICE][3].order });
 	});
 });

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -1,13 +1,9 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { COLOUR, PLAYER, VARIANTS, expandShortCard, setup, takeTurn } from '../test-utils.js';
-import * as ExAsserts from '../extra-asserts.js';
+import { PLAYER, setup, takeTurn } from '../test-utils.js';
 import HGroup from '../../src/conventions/h-group.js';
-import { ACTION, CLUE } from '../../src/constants.js';
 import logger from '../../src/tools/logger.js';
-import { take_action } from '../../src/conventions/h-group/take-action.js';
-import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
 
 logger.setLevel(logger.LEVELS.ERROR);
 
@@ -33,6 +29,7 @@ describe('double discard avoidance', () => {
 
 		// No one should be finessed by this as Alice was simply stalling.
 		const finessed = state.hands.map((hand, idx) => idx).filter(idx => state.hands[idx].some(c => game.common.thoughts[c.order].finessed));
+		assert.equal(finessed.length, 0);
 		assert.equal(game.common.waiting_connections.length, 0);
 	});
 

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -57,4 +57,27 @@ describe('double discard avoidance', () => {
 		const action = take_action(game);
 		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: state.hands[PLAYER.ALICE][3].order });
 	});
+
+	it(`doesn't treat a sarcastic discard as triggering DDA`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r3', 'y5', 'b2', 'g4'],
+			['b3', 'b1', 'g1', 'b3'],
+			['b1', 'b4', 'r4', 'r3']
+		], {
+			level: { min: 9 },
+			play_stacks: [0, 0, 0, 0, 0],
+			starting: PLAYER.BOB,
+			clue_tokens: 0,
+			discarded: ['b1']
+		});
+		const { state } = game;
+		takeTurn(game, 'Bob clues 1 to Cathy');
+		takeTurn(game, 'Cathy clues blue to Donald')
+		takeTurn(game, 'Donald discards b1', 'p3'); // Ends early game
+
+		// The sarcastic discard doesn't trigger dda.
+		assert.equal(state.dda, undefined);
+	});
+
 });

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -30,7 +30,7 @@ describe('double discard avoidance', () => {
 		takeTurn(game, 'Alice clues 5 to Bob');
 
 		// No one should be finessed by this as Alice was simply stalling.
-		const finessed = state.hands.map((hand, idx) => idx).filter(idx => state.hands[idx].some(c => game.common.thoughts[c.order].finessed));
+		const finessed = state.hands.filter(hand => hand.some(c => game.common.thoughts[c.order].finessed));
 		assert.equal(finessed.length, 0);
 		assert.equal(game.common.waiting_connections.length, 0);
 	});


### PR DESCRIPTION
This is an extremely simple version of double discard avoidance based on common knowledge to get an idea for how it might work. After implementing this, I feel that DDA needs to be allowed to be asymetric and should be a part of clue interpretation, e.g. you should be able to trigger connecting plays from players who know that you're not in DDA and ideally even have those unexpected plays result in players who thought you were in DDA rewind and interpret the clue knowing that you weren't.