### PR TITLE
Assume identity based on waiting connections.

### DIFF
--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -59,7 +59,7 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 				card.inferred = card.inferred.subtract(card.inferred.filter(inf => inf.playedBefore(identity)));
 
 				// If a waiting connection will reveal this card, assume it will be known in time.
-				const connection = common.waiting_connections.find(conn => conn.focused_card.order == card.order);
+				const connection = common.waiting_connections.find(conn => !conn.symmetric && conn.focused_card.order == card.order);
 				if (connection !== undefined)
 					card.inferred = card.inferred.intersect(connection.inference);
 			}

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -59,7 +59,7 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 				card.inferred = card.inferred.subtract(card.inferred.filter(inf => inf.playedBefore(identity)));
 
 				// If a waiting connection will reveal this card, assume it will be known in time.
-				const connection = common.waiting_connections.find(conn => !conn.symmetric && conn.focused_card.order == card.order);
+				const connection = common.waiting_connections.find(conn => !conn.symmetric && conn.focused_card.order == card.order && conn.target !== state.ourPlayerIndex);
 				if (connection !== undefined)
 					card.inferred = card.inferred.intersect(connection.inference);
 			}

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -54,8 +54,14 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 
 			// Remove inferences that will be proven false (i.e. after someone plays the card with such identity)
 			// Except the giver, who can't eliminate from their own hand
-			if (giver !== playerIndex)
+			if (giver !== playerIndex) {
 				card.inferred = card.inferred.subtract(card.inferred.filter(inf => inf.playedBefore(identity)));
+
+				// If a waiting connection will reveal this card, assume it will be known in time.
+				const connection = common.waiting_connections.find(conn => conn.focused_card.order == card.order);
+				if (connection !== undefined)
+					card.inferred = card.inferred.intersect(connection.inference);
+			}
 
 			return card.matches(identity, { infer: true, symmetric: true }) &&
 				state.deck[order].matches(identity, { assume: true }) &&

--- a/test/h-group/level-5.js
+++ b/test/h-group/level-5.js
@@ -332,6 +332,21 @@ describe('guide principle', () => {
 		const action = take_action(game);
 		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][0].order });
 	});
+
+	it(`understands a finesse on top of an in progress connection`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['p4', 'r3', 'g3', 'b3'],
+			['p1', 'r3', 'p1', 'y2'],
+			['b2', 'y3', 'b5', 'r4']
+		], { level: { min: 5 }, play_stacks: [1, 1, 1, 1, 0]});
+		takeTurn(game, 'Alice clues 3 to Bob'); // Finesses b2 -> b3.
+		takeTurn(game, 'Bob clues 5 to Donald'); // 5 save.
+		takeTurn(game, 'Cathy clues 5 to Donald'); // Should finesse b4 out of Alice's hand.
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['b4']);
+	})
 });
 
 describe('mistake recovery', () => {

--- a/test/h-group/level-5.js
+++ b/test/h-group/level-5.js
@@ -346,7 +346,23 @@ describe('guide principle', () => {
 
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order], ['b4']);
-	})
+	});
+
+	it(`understands a finesse on top of an in progress connection on us`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['p1', 'r3', 'p1', 'y2'],
+			['b2', 'y3', 'b5', 'r4'],
+			['y2', 'b4', 'b3', 'g4'],
+		], { level: { min: 5 }, starting: PLAYER.DONALD, play_stacks: [1, 1, 1, 1, 0]});
+		takeTurn(game, 'Donald clues 3 to Alice (slots 2,3,4)'); // Finesses b2 -> b3.
+		takeTurn(game, 'Alice clues 5 to Cathy'); // 5 save.
+		takeTurn(game, 'Bob clues 5 to Cathy'); // Should finesse y2, b4 out of Donald's hand.
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.DONALD][0].order].finessed, true);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.DONALD][1].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.DONALD][1].order], ['b4']);
+	});
 });
 
 describe('mistake recovery', () => {


### PR DESCRIPTION
This fixes a case that I've seen cause some bombs in self play. An ambiguous finesse is given, but one of the players who doesn't realize they're part of the ambiguous finesse gives a finesse based on it assuming that the card is known.