### PR TITLE
Prevent inBetween from crashing when giver and target coincide

### DIFF
--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -171,7 +171,7 @@ export function valuable_tempo_clue(game, clue, playables, focused_card) {
 export function inBetween(numPlayers, playerIndex, giver, target) {
 	const gap = (target - giver + numPlayers) % numPlayers;
 
-	return Utils.range(1, gap).some(inc => ((giver + inc) % numPlayers) === playerIndex);
+	return Utils.range(1, Math.max(gap, 1)).some(inc => ((giver + inc) % numPlayers) === playerIndex);
 }
 
 /**


### PR DESCRIPTION
In [this replay](https://hanab.live/replay/1205483#33), the bot crashed before making their move. The stack trace was:

```
│ file:///app/src/tools/util.js:97
│     return [...new Array(end - start).keys()].map(num => num + start);
│                ^
│
│ RangeError: Invalid array length
│     at Module.range (file:///app/src/tools/util.js:97:13)
│     at inBetween (file:///app/src/conventions/h-group/hanabi-logic.js:174:15)
│     at file:///app/src/conventions/h-group/take-action.js:278:111
│     at Array.some (<anonymous>)
│     at HGroup.take_action (file:///app/src/conventions/h-group/take-action.js:278:56)
│     at Timeout._onTimeout (file:///app/src/action-handler.js:117:52)
│     at listOnTimeout (node:internal/timers:573:17)
│     at process.processTimers (node:internal/timers:514:7)
```

So, [this line](https://github.com/WillFlame14/hanabi-bot/blob/d28b524c442d9bfbc1c9831f3966adbe37103a8a/src/conventions/h-group/take-action.js#L278) sometimes calls `inBetween` with `giver == target`. Maybe this is not the best solution, but to me it makes semantic sense to return false when `giver == target`.