### PR TITLE
Fix crash with empty range

### DIFF
--- a/src/tools/util.js
+++ b/src/tools/util.js
@@ -94,6 +94,8 @@ function emptyCmdQueue() {
  * @param {number} end
  */
 export function range(start, end) {
+	if (end <= start)
+		return [];
 	return [...new Array(end - start).keys()].map(num => num + start);
 }
 


### PR DESCRIPTION
When we request an impossible range this function crashes. Adds an early return for this condition.