### PR TITLE
Only scream discard for critical cards

### DIFF
--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -6,7 +6,7 @@ import { determine_focus, valuable_tempo_clue } from './hanabi-logic.js';
 import { cardValue } from '../../basics/hanabi-util.js';
 import { find_clue_value, order_1s } from './action-helper.js';
 import { find_clues } from './clue-finder/clue-finder.js';
-import { cardCount, cardTouched } from '../../variants.js';
+import { cardTouched } from '../../variants.js';
 import * as Utils from '../../tools/util.js';
 
 import logger from '../../tools/logger.js';
@@ -315,8 +315,7 @@ export function find_urgent_actions(game, play_clues, save_clues, fix_clues, sta
 
 				// As a last resort, only scream discard if it is critical.
 				const save_card = game.players[target].chop(state.hands[target]);
-				const remaining = cardCount(state.variant, save_card) - state.discard_stacks[save_card.suitIndex][save_card.rank - 1];
-				if (remaining === 1 && state.clue_tokens === 0 && chop !== undefined) {
+				if ((state.isCritical(save_card) || state.isPlayable(save_card)) && state.clue_tokens === 0 && chop !== undefined) {
 					urgent_actions[PRIORITY.PLAY_OVER_SAVE + nextPriority].push({ tableID, type: ACTION.DISCARD, target: chop.order });
 					continue;
 				}

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -6,7 +6,7 @@ import { determine_focus, valuable_tempo_clue } from './hanabi-logic.js';
 import { cardValue } from '../../basics/hanabi-util.js';
 import { find_clue_value, order_1s } from './action-helper.js';
 import { find_clues } from './clue-finder/clue-finder.js';
-import { cardTouched } from '../../variants.js';
+import { cardCount, cardTouched } from '../../variants.js';
 import * as Utils from '../../tools/util.js';
 
 import logger from '../../tools/logger.js';
@@ -313,7 +313,10 @@ export function find_urgent_actions(game, play_clues, save_clues, fix_clues, sta
 
 				const chop = common.chop(state.hands[state.ourPlayerIndex]);
 
-				if (state.clue_tokens === 0 && chop !== undefined) {
+				// As a last resort, only scream discard if it is critical.
+				const save_card = game.players[target].chop(state.hands[target]);
+				const remaining = cardCount(state.variant, save_card) - state.discard_stacks[save_card.suitIndex][save_card.rank - 1];
+				if (remaining === 1 && state.clue_tokens === 0 && chop !== undefined) {
 					urgent_actions[PRIORITY.PLAY_OVER_SAVE + nextPriority].push({ tableID, type: ACTION.DISCARD, target: chop.order });
 					continue;
 				}

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -315,7 +315,7 @@ export function find_urgent_actions(game, play_clues, save_clues, fix_clues, sta
 
 				// As a last resort, only scream discard if it is critical.
 				const save_card = game.players[target].chop(state.hands[target]);
-				if ((state.isCritical(save_card) || state.isPlayable(save_card)) && state.clue_tokens === 0 && chop !== undefined) {
+				if ((state.isCritical(save_card) || game.me.hypo_stacks[save_card.suitIndex] + 1 === save_card.rank) && state.clue_tokens === 0 && chop !== undefined) {
 					urgent_actions[PRIORITY.PLAY_OVER_SAVE + nextPriority].push({ tableID, type: ACTION.DISCARD, target: chop.order });
 					continue;
 				}

--- a/test/h-group/level-7.js
+++ b/test/h-group/level-7.js
@@ -51,8 +51,29 @@ describe('scream discard chop moves', () => {
 
 		const action = take_action(game);
 
-		// Alice should discard slot 4 as a SDCM.
+		// Alice should play as y2 is not critical or playable.
 		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][4].order });
+	});
+
+	it(`scream discards if playable`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'r2', 'g4', 'b4', 'y2'],
+			['g1', 'b3', 'r2', 'y3', 'p3']
+		], {
+			level: { min: 7 },
+			clue_tokens: 1,
+			play_stacks: [0, 1, 0, 0, 0],
+			starting: PLAYER.CATHY
+		});
+
+		takeTurn(game, 'Cathy clues red to Alice (slot 5)');
+
+		const action = take_action(game);
+
+		// Alice should discard slot 4 to SDCM as y2 is playable.
+		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: game.state.hands[PLAYER.ALICE][3].order });
+
 	});
 
 	it(`stalls after a scream discard`, () => {

--- a/test/h-group/level-7.js
+++ b/test/h-group/level-7.js
@@ -36,6 +36,25 @@ describe('scream discard chop moves', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4].order].chop_moved, true);
 	});
 
+	it(`only scream discards if critical`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'r2', 'g4', 'b4', 'y2'],
+			['g1', 'b3', 'r2', 'y3', 'p3']
+		], {
+			level: { min: 7 },
+			clue_tokens: 1,
+			starting: PLAYER.CATHY
+		});
+
+		takeTurn(game, 'Cathy clues red to Alice (slot 5)');
+
+		const action = take_action(game);
+
+		// Alice should discard slot 4 as a SDCM.
+		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][4].order });
+	});
+
 	it(`stalls after a scream discard`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],


### PR DESCRIPTION
As a last resort, a scream discard should only be used for critical cards.