### PR TITLE
Give fill-in stall clues on severity 2

### DIFF
--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -216,6 +216,11 @@ export function find_clues(game, giver = game.state.ourPlayerIndex, early_exits 
 					stall_clues[0].push(clue);
 					break;
 
+				case CLUE_INTERP.STALL_FILLIN:
+					logger.info('fill-in stall', logClue(clue));
+					stall_clues[2].push(clue);
+					break;
+
 				case CLUE_INTERP.STALL_LOCKED:
 					logger.info('locked hand save', logClue(clue));
 					stall_clues[3].push(clue);

--- a/test/h-group/level-9.js
+++ b/test/h-group/level-9.js
@@ -14,19 +14,21 @@ describe('double discard avoidance', () => {
 	it(`understands a clue from a player on double discard avoidance may be a stall`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],
-			['y2', 'y5', 'b2', 'g4'],
-			['b1', 'b5', 'b4', 'b2'],
-			['y4', 'y2', 'r4', 'r3']
+			['y5', 'y5', 'b4', 'g4'],
+			['b1', 'g4', 'b4', 'b2'],
+			['y4', 'y4', 'r4', 'r3']
 		], {
 			level: { min: 9 },
 			play_stacks: [2, 2, 2, 2, 2],
 			starting: PLAYER.DONALD
 		});
 		const { state } = game;
-		takeTurn(game, 'Donald discards r3', 'p3'); // Ends early game
+		takeTurn(game, 'Donald discards r3', 'p4'); // Ends early game
 
 		// A discard of a useful card means Alice is in a DDA situation.
 		ExAsserts.objHasProperties(game.state.dda, {suitIndex: COLOUR.RED, rank: 3});
+		const action = take_action(game);
+		ExAsserts.objHasProperties(action, { type: ACTION.RANK, target: PLAYER.BOB, value: 5 });
 		takeTurn(game, 'Alice clues 5 to Bob');
 
 		// No one should be finessed by this as Alice was simply stalling.
@@ -56,6 +58,36 @@ describe('double discard avoidance', () => {
 		// However, since Alice can see the other r3, Alice can discard.
 		const action = take_action(game);
 		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: state.hands[PLAYER.ALICE][3].order });
+	});
+
+	it(`will give a fill-in clue on double discard avoidance`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r4', 'y4', 'b3', 'g2'],
+			['b3', 'g2', 'b4', 'b5'],
+			['y4', 'b4', 'r4', 'r3']
+		], {
+			level: { min: 9 },
+			play_stacks: [0, 0, 0, 0, 0],
+			starting: PLAYER.BOB
+		});
+		const { state } = game;
+		takeTurn(game, 'Bob clues 5 to Cathy');
+		takeTurn(game, 'Cathy clues 2 to Bob');
+		takeTurn(game, 'Donald discards r3', 'p3'); // Ends early game
+
+		// A discard of a useful card means common knowledge is Alice is in a DDA situation.
+		ExAsserts.objHasProperties(state.dda, {suitIndex: COLOUR.RED, rank: 3});
+
+		// Alice gives a fill-in clue as the highest priority stall clue.
+		const action = take_action(game);
+		ExAsserts.objHasProperties(action, { type: ACTION.COLOUR, target: PLAYER.BOB, value: COLOUR.GREEN });
+		takeTurn(game, 'Alice clues green to Bob');
+
+		// No one should be finessed by this as Alice was simply stalling.
+		const finessed = state.hands.filter(hand => hand.some(c => game.common.thoughts[c.order].finessed));
+		assert.equal(finessed.length, 0);
+		assert.equal(game.common.waiting_connections.length, 0);
 	});
 
 	it(`doesn't treat a sarcastic discard as triggering DDA`, () => {


### PR DESCRIPTION
Fill in stalls are allowed at level 2 stalling severity and add more value than hard burns.