### PR TITLE
Recognize an ambiguous bluff and trigger replay on playing the original focused card

### DIFF
--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -63,7 +63,7 @@ export function valid_bluff(game, action, identity, reacting, connected) {
 		!(clue.type === CLUE.COLOUR && reacting === target) &&				// must not be self-colour bluff
 		!game.state.hands[reacting].some(c => {								// must not be confused with an existing finesse
 			const card = game.players[reacting].thoughts[c.order];
-			return card.finessed && card.possible.has(identity);
+			return !card.uncertain && card.finessed && card.possible.has(identity);
 		});
 }
 

--- a/src/conventions/h-group/interpret-play.js
+++ b/src/conventions/h-group/interpret-play.js
@@ -64,7 +64,7 @@ export function interpret_play(game, action) {
 	// Now that we know about this card, rewind from when the card was drawn
 	if (playerIndex === state.ourPlayerIndex) {
 		const card = common.thoughts[order];
-		const need_rewind = card.inferred.length !== 1 || !card.inferred.array[0].matches(identity) || common.play_links.some(link => link.orders.includes(order));
+		const need_rewind = card.uncertain || card.inferred.length !== 1 || !card.inferred.array[0].matches(identity) || common.play_links.some(link => link.orders.includes(order));
 
 		if (need_rewind && !card.rewinded) {
 			// If the rewind succeeds, it will redo this action, so no need to complete the rest of the function

--- a/src/conventions/h-player.js
+++ b/src/conventions/h-player.js
@@ -118,4 +118,20 @@ export class HGroup_Player extends Player {
 
 		return (card && !ignoreOrders.includes(card.order)) ? card : undefined;
 	}
+
+	/**
+	 * Finds all possible finesses, or an empty array if there are none.
+	 * @param {Hand} hand
+	 * @param {number[]} connected 		Orders of cards that have previously connected
+	 * @param {number[]} ignoreOrders 	Orders of cards to ignore when searching.
+	 */
+	find_ambiguous_finesses(hand, connected = [], ignoreOrders = []) {
+		let finessable = hand.filter(card => !card.clued && (!this.thoughts[card.order].finessed || this.thoughts[card.order].uncertain) && !connected.includes(card.order));
+
+		const certain = finessable.findIndex(card => !this.thoughts[card.order].uncertain);
+		if (certain != -1)
+			finessable = finessable.slice(0, certain + 1);
+
+		return finessable.filter(card => !ignoreOrders.includes(card.order));
+	}
 }

--- a/test/h-group/level-11.js
+++ b/test/h-group/level-11.js
@@ -913,6 +913,97 @@ describe('guide principle', () => {
 		takeTurn(game, 'Cathy clues purple to Bob'); // Cathy did not play and clued another bluff or finesse.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][1].order], ['r1']);
 	});
+
+	it(`understands a bluff on an ambiguous false finesse`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b3', 'y3', 'y2', 'g2'],
+			['r3', 'b3', 'p5', 'p4'],
+			['b1', 'r4', 'b2', 'y4']
+		], {
+			level: { min: 11 },
+			play_stacks: [1, 0, 0, 0, 0],
+			starting: PLAYER.BOB
+		});
+		takeTurn(game, 'Bob clues 2 to Alice (slot 3)');
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2].order], ['b2', 'r2']);
+
+		// Cathy could be bluffing out b1 or finessing a g1 in our hand.
+		takeTurn(game, 'Cathy clues green to Bob');
+
+		// Donald could be playing into the b1 > b2 finesse or a g2 bluff from Cathy.
+		takeTurn(game, 'Donald plays b1', 'r4');
+
+		// Alice can't know whether the g1 > g2 finesse is real until she knows whether Donald was bluffed.
+		// She should play the 2 first to find out.
+		const action = take_action(game);
+		ExAsserts.objHasProperties(action, {type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][2].order});
+		takeTurn(game, 'Alice plays r2 (slot 3)');
+
+		// Recognizing that Donald played b1 for the bluff, Alice is not finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, false);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3].order], ['g2']);
+	});
+
+	it(`understands an ambiguous bluff delaying a finesse`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b3', 'y3', 'y2', 'g2'],
+			['r3', 'b3', 'p5', 'p4'],
+			['b1', 'r4', 'b2', 'y4']
+		], {
+			level: { min: 11 },
+			play_stacks: [1, 0, 0, 0, 0],
+			starting: PLAYER.BOB
+		});
+		takeTurn(game, 'Bob clues 2 to Alice (slot 3)');
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2].order], ['b2', 'r2']);
+
+		// Cathy could be bluffing out b1 or finessing a g1 in our hand.
+		takeTurn(game, 'Cathy clues green to Bob');
+
+		// Donald could be playing into the b1 > b2 finesse or a g2 bluff from Cathy.
+		takeTurn(game, 'Donald plays b1', 'r4');
+
+		// Alice can't know whether the g1 > g2 finesse is real until she knows whether Donald was bluffed.
+		// She should play the 2 first to find out.
+		const action = take_action(game);
+		ExAsserts.objHasProperties(action, {type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][2].order});
+		takeTurn(game, 'Alice plays b2 (slot 3)');
+
+		// Recognizing that Donald played b1 for the finesse, Alice is finessed.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][1].order], ['g1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][1].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3].order], ['g1', 'g2']);
+	});
+
+	it(`understands delaying on an ambiguous bluff`, () => {
+		const game = setup(HGroup, [
+			['g1', 'r5', 'b2', 'g3'],
+			['xx', 'xx', 'xx', 'xx'],
+			['r3', 'b3', 'p5', 'p4'],
+			['b1', 'r4', 'b2', 'y4']
+		], {
+			level: { min: 11 },
+			play_stacks: [1, 0, 0, 0, 0],
+			starting: PLAYER.BOB
+		});
+		game.state.ourPlayerIndex = 1;
+		takeTurn(game, 'Bob clues 2 to Alice');
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2].order], ['b2', 'r2']);
+
+		// Cathy finessing out g1 in our hand.
+		takeTurn(game, 'Cathy clues green to Bob (slot 4)');
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3].order], ['g1', 'g2']);
+
+		takeTurn(game, 'Donald plays b1', 'r4');
+		takeTurn(game, 'Alice plays b2', 'b4');
+
+		// Alice is still finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][1].order].finessed, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3].order], ['g1', 'g2']);
+	});
 });
 
 describe('mistake recovery', () => {


### PR DESCRIPTION
This should allow recognizing situations such as in #315 where it may be ambiguous whether a card was played for a finesse in our hand or a bluff.